### PR TITLE
Improving the IO example

### DIFF
--- a/test/lib/elements/async_unix.ml
+++ b/test/lib/elements/async_unix.ml
@@ -26,20 +26,24 @@ module Async = struct
 
   type state = {
     mutable state : [ `Init | `Locked | `Alive | `Dead ];
+    mutable pipe_inn : Unix.file_descr;
     mutable pipe_out : Unix.file_descr;
+    mutable exn_bt : Exn_bt.t;
     reading : Awaiter.t list Atomic.t;
     writing : Awaiter.t list Atomic.t;
   }
 
   let key =
     (* In this case we really want to use DLS rather than TLS. *)
+    (* Unfortunately we cannot safely allocate a pipe here, so we use stdin
+       as a dummy value. *)
+    let dummy_pipe = Unix.stdin in
     DLS.new_key @@ fun () ->
     {
       state = `Init;
-      pipe_out =
-        (* Unfortunately we cannot safely allocate a pipe here, so we use stdin
-           as a dummy value. *)
-        Unix.stdin;
+      pipe_inn = dummy_pipe;
+      pipe_out = dummy_pipe;
+      exn_bt = Exn_bt.get_callstack 0 Exit;
       reading = Atomic.make [];
       writing = Atomic.make [];
     }
@@ -51,60 +55,72 @@ module Async = struct
          true
        end
 
-  let needs_init s = s.state != `Alive
-
-  let[@poll error] [@inline never] unlock s pipe_out =
-    s.pipe_out <- pipe_out;
-    s.state <- `Alive
+  let[@poll error] [@inline never] unlock s state = s.state <- state
 
   let wakeup s =
     let n = Unix.write s.pipe_out (Bytes.create 1) 0 1 in
     assert (n = 1)
 
-  let rec init s =
+  let io_thread s =
+    begin
+      try
+        (* The pipe is used to wake up the select after changing the lists of
+           reading and writing file descriptors. *)
+        let pipe_inn, pipe_out = Unix.pipe ~cloexec:true () in
+        s.pipe_inn <- pipe_inn;
+        s.pipe_out <- pipe_out;
+        unlock s `Alive;
+        (* This is the IO select loop that performs select and then wakes up
+           fibers blocked on IO. *)
+        while s.state == `Alive do
+          let rs, ws, _ =
+            Unix.select
+              (s.pipe_inn
+              :: List.map Awaiter.file_descr_of (Atomic.get s.reading))
+              (List.map Awaiter.file_descr_of (Atomic.get s.writing))
+              [] (-1.0)
+          in
+          List.iter
+            (Awaiter.signal_or_wakeup s.pipe_inn (Atomic.get s.reading))
+            rs;
+          List.iter (Awaiter.signal (Atomic.get s.writing)) ws;
+          Atomic.modify s.reading (List.fold_right Awaiter.reject rs);
+          Atomic.modify s.writing (List.fold_right Awaiter.reject ws)
+        done
+      with exn -> s.exn_bt <- Exn_bt.get exn
+    end;
+    unlock s `Dead;
+    if s.pipe_inn != Unix.stdin then Unix.close s.pipe_inn;
+    if s.pipe_out != Unix.stdin then Unix.close s.pipe_out
+
+  let start s =
     (* DLS initialization may be run multiple times, so we perform more involved
        initialization here. *)
-    if try_lock s then begin
-      (* The pipe is used to wake up the select after changing the lists of
-         reading and writing file descriptors. *)
-      let pipe_inn, pipe_out = Unix.pipe ~cloexec:true () in
-      unlock s pipe_out;
-      let t =
-        ()
-        |> Thread.create @@ fun () ->
-           (* This is the IO select loop that performs select and then wakes up
-              fibers blocked on IO. *)
-           while s.state != `Dead do
-             let rs, ws, _ =
-               Unix.select
-                 (pipe_inn
-                 :: List.map Awaiter.file_descr_of (Atomic.get s.reading))
-                 (List.map Awaiter.file_descr_of (Atomic.get s.writing))
-                 [] (-1.0)
-             in
-             List.iter
-               (Awaiter.signal_or_wakeup pipe_inn (Atomic.get s.reading))
-               rs;
-             List.iter (Awaiter.signal (Atomic.get s.writing)) ws;
-             Atomic.modify s.reading (List.fold_right Awaiter.reject rs);
-             Atomic.modify s.writing (List.fold_right Awaiter.reject ws)
-           done;
-           Unix.close pipe_inn;
-           Unix.close pipe_out
-      in
-      Domain.at_exit @@ fun () ->
-      s.state <- `Dead;
-      wakeup s;
-      Thread.join t
-    end
-    else if needs_init s then begin
-      Thread.yield ();
-      init s
-    end
+    match Thread.create io_thread s with
+    | thread ->
+        Domain.at_exit @@ fun () ->
+        unlock s `Dead;
+        wakeup s;
+        Thread.join thread;
+        if s.exn_bt.exn != Exit then Exn_bt.raise s.exn_bt
+    | exception exn ->
+        unlock s `Dead;
+        raise exn
+
+  let wait s =
+    while s.state == `Locked do
+      Thread.yield ()
+    done;
+    if s.state != `Alive then
+      invalid_arg "Async_unix: domain has been terminated"
+
+  let init s =
+    if try_lock s then start s;
+    wait s
 
   let get () =
     let s = DLS.get key in
-    if needs_init s then init s;
+    if s.state != `Alive then init s;
     s
 
   let await s r file_descr =

--- a/test/lib/elements/async_unix.ml
+++ b/test/lib/elements/async_unix.ml
@@ -138,16 +138,25 @@ end
 include Unix
 
 let read file_descr bytes pos len =
-  let s = Async.get () in
-  Async.await s s.reading file_descr;
-  Unix.read file_descr bytes pos len
+  match Unix.read file_descr bytes pos len with
+  | result -> result
+  | exception Unix.Unix_error ((EAGAIN | EWOULDBLOCK), _, _) ->
+      let s = Async.get () in
+      Async.await s s.reading file_descr;
+      Unix.read file_descr bytes pos len
 
 let write file_descr bytes pos len =
-  let s = Async.get () in
-  Async.await s s.writing file_descr;
-  Unix.write file_descr bytes pos len
+  match Unix.write file_descr bytes pos len with
+  | result -> result
+  | exception Unix.Unix_error ((EAGAIN | EWOULDBLOCK), _, _) ->
+      let s = Async.get () in
+      Async.await s s.writing file_descr;
+      Unix.write file_descr bytes pos len
 
 let accept ?cloexec file_descr =
-  let s = Async.get () in
-  Async.await s s.reading file_descr;
-  Unix.accept ?cloexec file_descr
+  match Unix.accept ?cloexec file_descr with
+  | result -> result
+  | exception Unix.Unix_error ((EAGAIN | EWOULDBLOCK), _, _) ->
+      let s = Async.get () in
+      Async.await s s.reading file_descr;
+      Unix.accept ?cloexec file_descr

--- a/test/lib/elements/async_unix.ml
+++ b/test/lib/elements/async_unix.ml
@@ -2,6 +2,8 @@ open Picos
 open Foundation
 
 module Async = struct
+  (* TODO: Use better data structures for awaiters than lists. *)
+
   module Awaiter = struct
     type t = { file_descr : Unix.file_descr; trigger : Trigger.as_signal }
 

--- a/test/lib/foundation/atomic.ml
+++ b/test/lib/foundation/atomic.ml
@@ -1,8 +1,0 @@
-include Stdlib.Atomic
-
-let rec update t fn =
-  let before = Stdlib.Atomic.get t in
-  let after = fn before in
-  if Stdlib.Atomic.compare_and_set t before after then before else update t fn
-
-let modify t fn = update t fn |> ignore

--- a/test/lib/foundation/atomic.mli
+++ b/test/lib/foundation/atomic.mli
@@ -1,7 +1,0 @@
-include module type of Stdlib.Atomic
-
-val update : 'a t -> ('a -> 'a) -> 'a
-(** *)
-
-val modify : 'a t -> ('a -> 'a) -> unit
-(** *)

--- a/test/lib/foundation/thread_atomic.ml
+++ b/test/lib/foundation/thread_atomic.ml
@@ -1,0 +1,13 @@
+let[@poll error] [@inline never] compare_and_set t before after =
+  !t == before
+  && begin
+       t := after;
+       true
+     end
+
+let rec update t fn =
+  let before = !t in
+  let after = fn before in
+  if compare_and_set t before after then before else update t fn
+
+let[@inline] modify t fn = update t fn |> ignore

--- a/test/lib/foundation/thread_atomic.mli
+++ b/test/lib/foundation/thread_atomic.mli
@@ -1,0 +1,12 @@
+(** Operations on [ref]s that are atomic with respect to systhreads.
+
+    ⚠️ These operations are not parallelism safe. *)
+
+val compare_and_set : 'a ref -> 'a -> 'a -> bool
+(** *)
+
+val update : 'a ref -> ('a -> 'a) -> 'a
+(** *)
+
+val modify : 'a ref -> ('a -> 'a) -> unit
+(** *)

--- a/test/test_server_and_client.ml
+++ b/test/test_server_and_client.ml
@@ -51,6 +51,7 @@ let main () =
       Sleep.sleepf 0.01
     done;
     Printf.printf "  Client connected\n%!";
+    Async_unix.set_nonblock socket;
     let bytes = Bytes.create n in
     let n = Async_unix.write socket bytes 0 (Bytes.length bytes) in
     Printf.printf "  Client wrote %d\n%!" n;

--- a/test/test_server_and_client.ml
+++ b/test/test_server_and_client.ml
@@ -4,11 +4,7 @@ open Elements
 let main () =
   Bundle.run @@ fun bundle ->
   let n = 100 in
-  let port =
-    Random.self_init ();
-    Random.int 1000 + 3000
-  in
-  let server_addr = Async_unix.(ADDR_INET (inet_addr_loopback, port)) in
+  let server_addr = ref None in
 
   let server =
     Bundle.fork bundle @@ fun () ->
@@ -20,7 +16,8 @@ let main () =
         Async_unix.socket ~cloexec:true PF_INET SOCK_STREAM 0
       in
       Async_unix.set_nonblock socket;
-      Async_unix.bind socket server_addr;
+      Async_unix.bind socket Async_unix.(ADDR_INET (inet_addr_loopback, 0));
+      server_addr := Some (Async_unix.getsockname socket);
       Async_unix.listen socket 1;
       Printf.printf "  Server listening\n%!";
       Async_unix.accept ~cloexec:true socket |> fst
@@ -40,16 +37,18 @@ let main () =
       finally Async_unix.close @@ fun () ->
       Async_unix.socket ~cloexec:true PF_INET SOCK_STREAM 0
     in
-    let retries = ref 100 in
-    while
-      match Async_unix.connect socket server_addr with
-      | () -> false
-      | exception Async_unix.Unix_error (ECONNREFUSED, _, _) ->
-          decr retries;
-          0 <= !retries || failwith "Could not connect to server"
-    do
-      Sleep.sleepf 0.01
-    done;
+    let server_addr =
+      let rec loop retries =
+        match !server_addr with
+        | None ->
+            if retries < 0 then failwith "No server address";
+            Sleep.sleepf 0.01;
+            loop (retries - 1)
+        | Some addr -> addr
+      in
+      loop 100
+    in
+    Async_unix.connect socket server_addr;
     Printf.printf "  Client connected\n%!";
     Async_unix.set_nonblock socket;
     let bytes = Bytes.create n in


### PR DESCRIPTION
This PR:
* Improves the initialization of auxiliary threads such that failure to create thread should not leave program in invalid state.
* Optimizes `Async_unix` examples to attempt operations (`read`, `write`, `accept`) synchronously and then only in case the operation raises `EAGAIN` or `EWOULDBLOCK` is the operation delegated to the IO thread running select.
* Optimizes `Async_unix` to avoids the use of `Atomic`.  The operations are performed within a single domain, so it is possible to just rely on `poll error` to ensure thread switches do not break atomicity.
* Optimizes `Async_unix` to avoid unnecessary wakeups.