### PR TITLE
Check trigger has not been signaled before attaching to computation

### DIFF
--- a/lib/picos/bootstrap.ml
+++ b/lib/picos/bootstrap.ml
@@ -64,6 +64,9 @@ module Computation = struct
     match Atomic.get t with
     | Returned _ | Canceled _ -> false
     | Continue r as before ->
+        (* We check the trigger before potential allocations. *)
+        (not (Trigger.is_signaled trigger))
+        &&
         let after =
           if 0 <= r.balance then
             Continue

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -646,7 +646,7 @@ module Computation : sig
   (** [try_attach computation trigger] tries to attach the trigger to be
       signaled on completion of the computation and returns [true] on success.
       Otherwise returns [false], which means that the computation has already
-      been completed. *)
+      been completed or the trigger has already been signaled. *)
 
   val detach : ('a, [> `Await ]) t -> [> `Signal ] Trigger.t -> unit
   (** [detach computation trigger] {{!Trigger.signal} signals} the trigger and


### PR DESCRIPTION
This PR changes the specification of `Computation.try_attach` to also allow it to return `false` in case the trigger has already been signaled.  The implementation is also changed to check for that.  This allows a scheduler to potentially avoid a bit of work.