### PR TITLE
Make `DLS` always lazy

### DIFF
--- a/lib/picos/domain.ocaml4.ml
+++ b/lib/picos/domain.ocaml4.ml
@@ -1,9 +1,30 @@
 let at_exit = Stdlib.at_exit
 
 module DLS = struct
-  type 'a key = 'a ref
+  type 'a state = Value of { mutable value : 'a } | Default of (unit -> 'a)
+  type 'a key = 'a state ref
 
-  let new_key default = ref (default ())
-  let get = ( ! )
-  let set = ( := )
+  let new_key default = ref (Default default)
+
+  open struct
+    let[@poll error] [@inline never] compare_and_set key before after =
+      !key == before
+      && begin
+           key := after;
+           true
+         end
+  end
+
+  let rec get key =
+    match !key with
+    | Value r -> r.value
+    | Default default as before ->
+        let value = default () in
+        if compare_and_set key before (Value { value }) then value else get key
+
+  let rec set key value =
+    match !key with
+    | Value r -> r.value <- value
+    | Default _ as before ->
+        if not (compare_and_set key before (Value { value })) then set key value
 end

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -235,12 +235,10 @@ module DLS : sig
 
   val new_key : (unit -> 'a) -> 'a key
   (** [new_key compute] allocates a new key for associating values in storage
-      associated with domains.  The behavior depends on OCaml version:
-
-      - On OCaml 5 the initial value for each domain is [compute]d by calling
-        the given function if the [key] is {{!get}read} before it has been
-        {{!set}written}.
-      - On OCaml 4 the initial value is computed once immediately. *)
+      associated with domains.  The initial value for each domain is [compute]d
+      by calling the given function if the [key] is {{!get}read} before it has
+      been {{!set}written}.  The [compute] function might be called multiple
+      times per domain, but only one result will be used. *)
 
   val get : 'a key -> 'a
   (** [get key] returns the value associated with the [key] in the storage
@@ -264,15 +262,9 @@ module TLS : sig
 
   val new_key : (unit -> 'a) -> 'a key
   (** [new_key compute] allocates a new key for associating values in storage
-      associated with threads.  The behavior depends on OCaml version and the
-      availability of the [threads.posix] library:
-
-      - On OCaml 5 and on OCaml 4, when [threads.posix] library is available,
-        the initial value for each thread is [compute]d by calling the given
-        function if the [key] is {{!get}read} before it has been
-        {{!set}written}.
-      - On OCaml 4, when [threads.posix] library is not available, the initial
-        value is computed once immediately. *)
+      associated with threads.  The initial value for each thread is [compute]d
+      by calling the given function if the [key] is {{!get}read} before it has
+      been {{!set}written}. *)
 
   val get : 'a key -> 'a
   (** [get key] returns the value associated with the [key] in the storage


### PR DESCRIPTION
This makes the `DLS` implementation lazy, lock-free, and thread-safe on OCaml 4.

There should really also be a `DLS.compare_and_set: 'a key -> 'a -> 'a -> unit` exposed to allow correct thread-safe lock-free updates, but OCaml 5's `Domain.DLS` does not provide such an operation.

Note that [OCaml 5's `Domain.DLS` is currently not thread-safe](https://github.com/ocaml/ocaml/issues/12677).