### PR TITLE
Fix `Mpsc_queue` order

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,6 +37,14 @@
    (and
     (>= 1.7.0)
     :with-test))
+  (qcheck-core
+   (and
+    (>= 0.21.2)
+    :with-test))
+  (qcheck-stm
+   (and
+    (>= 0.3)
+    :with-test))
   (mdx
    (and
     (>= 2.3.1)

--- a/picos.opam
+++ b/picos.opam
@@ -14,6 +14,8 @@ depends: [
   "mtime" {>= "2.0.0"}
   "psq" {>= "0.2.1"}
   "alcotest" {>= "1.7.0" & with-test}
+  "qcheck-core" {>= "0.21.2" & with-test}
+  "qcheck-stm" {>= "0.3" & with-test}
   "mdx" {>= "2.3.1" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
   "js_of_ocaml" {>= "5.4.0" & with-test}

--- a/test/dune
+++ b/test/dune
@@ -28,6 +28,18 @@
  (libraries test_server_and_client))
 
 (test
+ (name test_mpsc_queue)
+ (modules test_mpsc_queue)
+ (libraries
+  foundation
+  qcheck-core
+  qcheck-core.runner
+  qcheck-stm.stm
+  qcheck-stm.sequential)
+ (action
+  (run %{test} --verbose)))
+
+(test
  (name test_js_of_ocaml)
  (modules test_js_of_ocaml)
  (modes js)

--- a/test/lib/foundation/mpsc_queue.ml
+++ b/test/lib/foundation/mpsc_queue.ml
@@ -25,7 +25,7 @@ let dequeue t =
       | [] -> raise_notrace Empty
       | [ x ] -> x
       | x :: xs -> begin
-          match List.rev_append [ x ] xs with
+          match List.rev_append xs [ x ] with
           | x :: xs ->
               t.head := xs;
               x

--- a/test/test_mpsc_queue.ml
+++ b/test/test_mpsc_queue.ml
@@ -1,0 +1,53 @@
+open Foundation
+
+module Spec = struct
+  type cmd = Enq of int | Deq
+
+  let show_cmd c =
+    match c with Enq i -> "Enq " ^ string_of_int i | Deq -> "Deq"
+
+  type state = int list
+  type sut = int Mpsc_queue.t
+
+  let arb_cmd _s =
+    QCheck.(
+      make ~print:show_cmd
+        (Gen.oneof [ Gen.map (fun i -> Enq i) Gen.nat; Gen.return Deq ]))
+
+  let init_state = []
+  let init_sut () = Mpsc_queue.create ()
+  let cleanup _ = ()
+
+  let next_state c s =
+    match c with
+    | Enq i -> s @ [ i ]
+    | Deq -> ( match s with _ :: s -> s | [] -> [])
+
+  let precond _ _ = true
+
+  let run c d =
+    let open STM in
+    match c with
+    | Enq i -> Res (unit, Mpsc_queue.enqueue d i)
+    | Deq ->
+        Res
+          ( option int,
+            match Mpsc_queue.dequeue d with
+            | i -> Some i
+            | exception Mpsc_queue.Empty -> None )
+
+  let postcond c (s : state) res =
+    let open STM in
+    match (c, res) with
+    | Enq _, Res ((Unit, _), ()) -> true
+    | Deq, Res ((Option Int, _), res) ->
+        (match s with [] -> None | x :: _ -> Some x) = res
+    | _, _ -> false
+end
+
+module Seq = STM_sequential.Make (Spec)
+
+let () =
+  let count = 1000 in
+  QCheck_base_runner.run_tests_main
+    [ Seq.agree_test ~count ~name:"STM Mpsc_queue test sequential" ]


### PR DESCRIPTION
The parameters to `List.rev_append` were given in the incorrect order.  Fixes #20.