### PR TITLE
Testing with DSCheck

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -69,5 +69,9 @@
    (and
     (>= 0.4.1)
     :with-test))
+  (dscheck
+   (and
+    (>= 0.3.0)
+    :with-test))
   (ocaml
    (>= 4.12.0))))

--- a/picos.opam
+++ b/picos.opam
@@ -22,6 +22,7 @@ depends: [
   "conf-npm" {arch != "x86_32" & with-test}
   "saturn" {>= "0.4.1" & with-test}
   "saturn_lockfree" {>= "0.4.1" & with-test}
+  "dscheck" {>= "0.3.0" & with-test}
   "ocaml" {>= "4.12.0"}
   "odoc" {with-doc}
 ]

--- a/test/dune
+++ b/test/dune
@@ -5,15 +5,34 @@
   (>= %{ocaml_version} 5.0.0))
  (libraries picos schedulers unix))
 
+;;
+
 (test
  (name bench_mpsc_queue)
  (modules bench_mpsc_queue)
  (libraries foundation unix saturn saturn_lockfree domain_shims))
 
+;;
+
 (test
  (name test_picos)
  (modules test_picos)
  (libraries picos foundation alcotest unix domain_shims))
+
+;;
+
+(rule
+ (action
+  (progn
+   (copy ../lib/picos/exn_bt.ml exn_bt.ml)
+   (copy ../lib/picos/bootstrap.ml bootstrap.ml))))
+
+(test
+ (name test_picos_dscheck)
+ (modules test_picos_dscheck bootstrap exn_bt)
+ (libraries backoff traced_atomic dscheck alcotest))
+
+;;
 
 (library
  (name test_server_and_client)
@@ -32,6 +51,8 @@
  (modules test_server_and_client_threads)
  (libraries test_server_and_client))
 
+;;
+
 (test
  (name test_mpsc_queue)
  (modules test_mpsc_queue)
@@ -43,6 +64,8 @@
   qcheck-stm.sequential)
  (action
   (run %{test} --verbose)))
+
+;;
 
 (test
  (name test_js_of_ocaml)

--- a/test/lib/traced_atomic/atomic.ml
+++ b/test/lib/traced_atomic/atomic.ml
@@ -1,0 +1,1 @@
+include Dscheck.TracedAtomic

--- a/test/lib/traced_atomic/dune
+++ b/test/lib/traced_atomic/dune
@@ -1,0 +1,5 @@
+(library
+ (name traced_atomic)
+ (modules atomic)
+ (wrapped false)
+ (libraries dscheck))

--- a/test/test_picos_dscheck.ml
+++ b/test/test_picos_dscheck.ml
@@ -1,0 +1,127 @@
+(** These tests are using DSCheck, which basically goes through all the possible
+    interleavings of [Atomic] operations performed by different [Atomic.spawn]ed
+    fibers. *)
+
+open Bootstrap
+
+let sum_as fn xs = Array.fold_left (fun sum x -> sum + fn x) 0 xs
+let ( += ) x y = x := !x + y
+
+(** This tries to cover most of the contract of [Trigger]s. *)
+let test_trigger_contract () =
+  let signaled_total = ref 0
+  and won_total = ref 0
+  and lost_total = ref 0
+  and raised_total = ref 0 in
+  let () =
+    Atomic.trace @@ fun () ->
+    let trigger = Trigger.create () in
+    let () = Atomic.check @@ fun () -> Trigger.is_initial trigger in
+    let signaled = ref 0 and won = ref 0 and lost = ref 0 and raised = ref 0 in
+    for _ = 1 to 2 do
+      Atomic.spawn @@ fun () -> Trigger.signal trigger
+    done;
+    for _ = 1 to 2 do
+      Atomic.spawn @@ fun () ->
+      match Trigger.on_signal trigger `X `Y (fun _ `X `Y -> incr signaled) with
+      | success -> if success then incr won else incr lost
+      | exception Invalid_argument _ -> incr raised
+    done;
+    Atomic.final @@ fun () ->
+    Atomic.check @@ fun () ->
+    signaled_total += !signaled;
+    won_total += !won;
+    lost_total += !lost;
+    raised_total += !raised;
+    Trigger.is_signaled trigger
+    && !won <= 1 && !won = !signaled && !lost <= 2 && !raised <= !won
+    && !raised = Bool.to_int (!lost = 0)
+    && !won + !lost + !raised = 2
+  in
+  [ signaled_total; won_total; lost_total; raised_total ]
+  |> List.iter @@ fun total -> if !total = 0 then Alcotest.fail "uncovered case"
+
+(** This tries to cover much of the public contract of [Computation]s. *)
+let test_computation_contract () =
+  let attached_total = ref 0 and unattached_total = ref 0 in
+  let () =
+    Atomic.trace @@ fun () ->
+    let computation = Computation.create () in
+    let () = Atomic.spawn @@ fun () -> Computation.return computation 101 in
+    let () =
+      Atomic.spawn @@ fun () ->
+      Computation.cancel computation (Exn_bt.get_callstack 1 Exit)
+    in
+    let triggers = Array.init 2 @@ fun _ -> Trigger.create () in
+    let attached = ref 0 and unattached = ref 0 in
+    let () =
+      triggers
+      |> Array.iter @@ fun trigger ->
+         Atomic.spawn @@ fun () ->
+         if Computation.try_attach computation trigger then incr attached
+         else incr unattached
+    in
+    Atomic.final @@ fun () ->
+    Atomic.check @@ fun () ->
+    attached_total += !attached;
+    unattached_total += !unattached;
+    begin
+      match Computation.peek computation with
+      | Some (Ok 101) | Some (Error { exn = Exit; _ }) -> true
+      | _ -> false
+    end
+    && !attached + !unattached = Array.length triggers
+    && !attached
+       = sum_as
+           (fun trigger -> Bool.to_int (Trigger.is_signaled trigger))
+           triggers
+  in
+  [ attached_total; unattached_total ]
+  |> List.iter @@ fun total -> if !total = 0 then Alcotest.fail "uncovered case"
+
+(** This covers the contract of [Computation] to remove detached triggers.
+
+    Testing this through the public API would require relying on GC
+    statistics. *)
+let test_computation_removes_triggers () =
+  Atomic.trace @@ fun () ->
+  let computation = Computation.create () in
+  let triggers = Array.init 4 @@ fun _ -> Trigger.create () in
+  let () =
+    triggers
+    |> Array.iter @@ fun trigger ->
+       Atomic.spawn @@ fun () ->
+       Atomic.check (fun () -> Computation.try_attach computation trigger);
+       Computation.detach computation trigger
+  in
+  Atomic.final @@ fun () ->
+  Atomic.check @@ fun () ->
+  Array.for_all Trigger.is_signaled triggers
+  &&
+  match Atomic.get computation with
+  | Canceled _ | Returned _ -> false
+  | Continue { balance; triggers } ->
+      balance <= 0
+      && List.length triggers <= 2
+      &&
+      let trigger = Trigger.create () in
+      Computation.try_attach computation trigger
+      && begin
+           match Atomic.get computation with
+           | Canceled _ | Returned _ -> false
+           | Continue { balance; triggers } ->
+               balance = 1 && triggers = [ trigger ]
+         end
+
+let () =
+  Alcotest.run "Picos DSCheck"
+    [
+      ( "Trigger",
+        [ Alcotest.test_case "basic contract" `Quick test_trigger_contract ] );
+      ( "Computation",
+        [
+          Alcotest.test_case "basic contract" `Quick test_computation_contract;
+          Alcotest.test_case "removes triggers" `Quick
+            test_computation_removes_triggers;
+        ] );
+    ]


### PR DESCRIPTION
This adds tests of the `Trigger` and `Computation` concepts using DSCheck.  The implementations of `Trigger` and `Computation` are pretty simple at this point &mdash; almost obviously correct &mdash; but it doesn't hurt to check them.

One thing that came to mind while writing the tests is that it would likely be better to change from `Computation.return` and `Computation.cancel` to `Computation.try_return` and `Computation.try_cancel`.  I'll leave that to a separate PR.