### PR TITLE
Add `try` versions of `Computation` completion actions

### DIFF
--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -579,17 +579,32 @@ module Computation : sig
   val finished : (unit, [ `Await | `Cancel | `Return ]) t
   (** [finished] is a constant finished computation. *)
 
+  val try_return : ('a, [> `Return ]) t -> 'a -> bool
+  (** [try_return computation value] attempts to complete the computation with
+      the specified [value] and returns [true] on success.  Otherwise returns
+      [false], which means that the computation had already been completed
+      before. *)
+
   val return : ('a, [> `Return ]) t -> 'a -> unit
-  (** [return computation value] attempts to complete the computation with the
-      specified [value]. *)
+  (** [return computation value] is equivalent to
+      [try_return computation value |> ignore]. *)
+
+  val try_finish : (unit, [> `Return ]) t -> bool
+  (** [try_finish computation] is equivalent to [try_return computation ()]. *)
 
   val finish : (unit, [> `Return ]) t -> unit
-  (** [finish computation] is equivalent to [return computation ()]. *)
+  (** [finish computation] is equivalent to
+      [try_finish computation |> ignore]. *)
+
+  val try_capture : ('a, [> `Cancel | `Return ]) t -> ('b -> 'a) -> 'b -> bool
+  (** [try_capture computation fn x] calls [fn x] and tries to complete the
+      computation with the value returned or the exception raised by the call
+      and returns [true] on success.  Otherwise returns [false], which means
+      that the computation had already been completed before. *)
 
   val capture : ('a, [> `Cancel | `Return ]) t -> ('b -> 'a) -> 'b -> unit
-  (** [capture computation fn x] calls [fn x] and tries to complete the
-      computation with the value returned or the exception raised by the
-      call. *)
+  (** [capture computation fn x] is equivalent to
+      [try_capture computation fn x |> ignore]. *)
 
   val cancel_after :
     ('a, [> `Await | `Cancel ]) t -> seconds:float -> Exn_bt.t -> unit
@@ -617,9 +632,15 @@ module Computation : sig
   (** Synonym for a packed computation that only allows cancelation aside from
       await. *)
 
+  val try_cancel : ('a, [> `Cancel ]) t -> Exn_bt.t -> bool
+  (** [try_cancel computation exn_bt] attempts to mark the computation as
+      canceled with the specified exception and backtrace and returns [true] on
+      success.  Otherwise returns [false], which means that the computation had
+      already been completed before. *)
+
   val cancel : ('a, [> `Cancel ]) t -> Exn_bt.t -> unit
-  (** [cancel computation exn_bt] attempts to mark the computation as canceled
-      with the specified exception and backtrace. *)
+  (** [cancel computation exn_bt] is equivalent to
+      [try_cancel computation exn_bt |> ignore]. *)
 
   (** {2 Interface for polling} *)
 

--- a/test/lib/elements/promise.ml
+++ b/test/lib/elements/promise.ml
@@ -6,7 +6,7 @@ type 'a unpublished = ('a, [ `Await | `Cancel | `Return ]) Computation.t
 let await = Computation.await
 let[@inline] of_computation x = (x :> 'a t)
 let peek t = if Computation.is_running t then None else Some (await t)
-let cancel = Computation.cancel
+let try_cancel = Computation.try_cancel
 
 module Infix = struct
   let ( let+ ) x xy =
@@ -54,6 +54,6 @@ let both x y =
   ()
 
 let create = Computation.create
-let return_to = Computation.return
-let reify_to t thunk = Computation.capture t thunk ()
+let try_return_to = Computation.try_return
+let try_reify_to t thunk = Computation.try_capture t thunk ()
 let publish = of_computation

--- a/test/lib/elements/promise.mli
+++ b/test/lib/elements/promise.mli
@@ -17,7 +17,7 @@ val peek : 'a t -> 'a option
 val both : unit t -> unit t -> unit t
 (** *)
 
-val cancel : 'a t -> Picos.Exn_bt.t -> unit
+val try_cancel : 'a t -> Picos.Exn_bt.t -> bool
 (** *)
 
 module Infix : sig
@@ -44,10 +44,10 @@ type !'a unpublished
 val create : unit -> 'a unpublished
 (** *)
 
-val return_to : 'a unpublished -> 'a -> unit
+val try_return_to : 'a unpublished -> 'a -> bool
 (** *)
 
-val reify_to : 'a unpublished -> (unit -> 'a) -> unit
+val try_reify_to : 'a unpublished -> (unit -> 'a) -> bool
 (** *)
 
 val publish : 'a unpublished -> 'a t


### PR DESCRIPTION
While the result is often not interesting, there are cases where knowing whether a particular call completed the computation can be useful.