### PR TITLE
Minor refactor to keep `t` as first and `backoff` as last argument

### DIFF
--- a/test/lib/foundation/mpsc_queue.ml
+++ b/test/lib/foundation/mpsc_queue.ml
@@ -5,13 +5,13 @@ let create () =
   let head = Multicore_magic.copy_as_padded @@ ref [] in
   Multicore_magic.copy_as_padded { tail; head }
 
-let rec enqueue backoff t x =
+let rec enqueue t x backoff =
   let before = Atomic.get t.tail in
   let after = x :: before in
   if not (Atomic.compare_and_set t.tail before after) then
-    enqueue (Backoff.once backoff) t x
+    enqueue t x (Backoff.once backoff)
 
-let enqueue t x = enqueue Backoff.default t x
+let enqueue t x = enqueue t x Backoff.default
 
 exception Empty
 


### PR DESCRIPTION
Having the `backoff` last results in smaller code in some cases and keeping the `t` first is helps to keep things more consistent.