### PR TITLE
Upgrade DSCheck to allow OCaml-CI test on OCaml 4

### DIFF
--- a/bench/bench_current.ml
+++ b/bench/bench_current.ml
@@ -8,7 +8,7 @@ let run_one ~budgetf ~n_domains () =
 
   let init _ = Atomic.set n_ops_todo n_ops in
   let work _ () =
-    Schedulers.Fifos.run ~forbid:false @@ fun () ->
+    Scheduler.run @@ fun () ->
     let rec work () =
       let n = Util.alloc n_ops_todo in
       if n <> 0 then

--- a/bench/bench_mpsc_queue.ml
+++ b/bench/bench_mpsc_queue.ml
@@ -51,7 +51,9 @@ let run_one ~budgetf ~n_adders () =
         if 0 < n then
           match Queue.dequeue t with
           | _ -> loop (n - 1)
-          | exception Queue.Empty -> loop n
+          | exception Queue.Empty ->
+              Domain.cpu_relax ();
+              loop n
       in
       loop n_msgs
   in

--- a/bench/dune
+++ b/bench/dune
@@ -12,7 +12,9 @@ let () =
  (libraries
   picos
   foundation
-  schedulers
+  (select scheduler.ml from
+   (schedulers -> scheduler.ocaml5.ml)
+   (           -> scheduler.ocaml4.ml))
   multicore-bench
   multicore-magic |}
   ^ maybe_domain_shims ^ {| ))

--- a/bench/scheduler.ocaml4.ml
+++ b/bench/scheduler.ocaml4.ml
@@ -1,0 +1,1 @@
+let run action = action ()

--- a/bench/scheduler.ocaml5.ml
+++ b/bench/scheduler.ocaml5.ml
@@ -1,0 +1,3 @@
+open Schedulers
+
+let run action = Fifos.run ~forbid:false action

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 3.9)
+(lang dune 3.14)
 
 (name picos)
 
@@ -67,17 +67,17 @@
    (and
     (<> :arch "x86_32")
     :with-test))
-  (saturn
-   (and
-    (>= 0.4.1)
-    :with-test))
-  (saturn_lockfree
-   (and
-    (>= 0.4.1)
-    :with-test))
   (dscheck
    (and
-    (>= 0.3.0)
+    (>= 0.4.0)
     :with-test))
+  (sherlodoc
+   (and
+    (>= 0.2)
+    :with-doc))
+  (odoc
+   (and
+    (>= 2.4.1)
+    :with-doc))
   (ocaml
    (>= 4.12.0))))

--- a/picos.opam
+++ b/picos.opam
@@ -7,7 +7,7 @@ license: "ISC"
 homepage: "https://github.com/ocaml-multicore/picos"
 bug-reports: "https://github.com/ocaml-multicore/picos/issues"
 depends: [
-  "dune" {>= "3.9"}
+  "dune" {>= "3.14"}
   "thread-local-storage" {>= "0.1"}
   "backoff" {>= "0.1.0"}
   "mtime" {>= "2.0.0"}
@@ -21,11 +21,10 @@ depends: [
   "domain_shims" {>= "0.1.0" & with-test}
   "js_of_ocaml" {>= "5.4.0" & with-test}
   "conf-npm" {arch != "x86_32" & with-test}
-  "saturn" {>= "0.4.1" & with-test}
-  "saturn_lockfree" {>= "0.4.1" & with-test}
-  "dscheck" {>= "0.3.0" & with-test}
+  "dscheck" {>= "0.4.0" & with-test}
+  "sherlodoc" {>= "0.2" & with-doc}
+  "odoc" {>= "2.4.1" & with-doc}
   "ocaml" {>= "4.12.0"}
-  "odoc" {with-doc}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/test/dune
+++ b/test/dune
@@ -14,6 +14,8 @@
 (test
  (name test_picos_dscheck)
  (modules test_picos_dscheck bootstrap exn_bt)
+ (build_if
+  (>= %{ocaml_version} 5))
  (libraries backoff traced_atomic dscheck alcotest))
 
 ;;

--- a/test/lib/traced_atomic/dune
+++ b/test/lib/traced_atomic/dune
@@ -2,4 +2,6 @@
  (name traced_atomic)
  (modules atomic)
  (wrapped false)
+ (enabled_if
+  (>= %{ocaml_version} 5))
  (libraries dscheck))


### PR DESCRIPTION
This PR upgrades to use [new version of the DSCheck package](https://github.com/ocaml-multicore/dscheck/pull/26) that is available on OCaml 4.  This allows [OCaml-CI](https://github.com/ocurrent/ocaml-ci) to build and run tests on OCaml 4.