### PR TITLE
Drop phantom types

### DIFF
--- a/bench/bench_current.ml
+++ b/bench/bench_current.ml
@@ -14,7 +14,7 @@ let run_one ~budgetf ~n_domains () =
       if n <> 0 then
         let rec loop n =
           if 0 < n then
-            let _ : _ Fiber.t = Fiber.current () in
+            let _ : Fiber.t = Fiber.current () in
             loop (n - 1)
           else work ()
         in

--- a/lib/picos/default.ml
+++ b/lib/picos/default.ml
@@ -3,7 +3,7 @@ open struct
     type t = {
       mutex : Mutex.t;
       condition : Condition.t;
-      fiber : [ `Sync | `Async ] Bootstrap.Fiber.t;
+      fiber : Bootstrap.Fiber.t;
     }
 
     open struct
@@ -70,7 +70,7 @@ open struct
       | Entry : {
           time : Mtime.span;
           exn_bt : Exn_bt.t;
-          computation : 'a Bootstrap.Computation.as_cancelable;
+          computation : 'a Bootstrap.Computation.t;
         }
           -> t
 

--- a/lib/picos/effects_intf.ocaml4.ml
+++ b/lib/picos/effects_intf.ocaml4.ml
@@ -3,16 +3,16 @@ module type Exn_bt = sig
 end
 
 module type Trigger = sig
-  type _ t
+  type t
   type exn_bt
 end
 
 module type Computation = sig
-  type _ as_cancelable
+  type _ t
   type exn_bt
 end
 
 module type Fiber = sig
-  type _ t
-  type _ as_cancelable
+  type t
+  type _ computation
 end

--- a/test/lib/elements/async_unix.ml
+++ b/test/lib/elements/async_unix.ml
@@ -5,7 +5,7 @@ module Async = struct
   (* TODO: Use better data structures for awaiters than lists. *)
 
   module Awaiter = struct
-    type t = { file_descr : Unix.file_descr; trigger : Trigger.as_signal }
+    type t = { file_descr : Unix.file_descr; trigger : Trigger.t }
 
     let file_descr_of t = t.file_descr
 
@@ -138,7 +138,7 @@ module Async = struct
 
   let await s r file_descr =
     let trigger = Trigger.create () in
-    let awaiter = Awaiter.{ file_descr; trigger :> Trigger.as_signal } in
+    let awaiter = Awaiter.{ file_descr; trigger } in
     Thread_atomic.modify r (List.cons awaiter);
     wakeup s;
     match Trigger.await trigger with

--- a/test/lib/elements/bundle.ml
+++ b/test/lib/elements/bundle.ml
@@ -3,10 +3,7 @@ open Picos
 (* TODO: propagation of all exceptions? *)
 (* TODO: cancelation forbidden? *)
 
-type t = {
-  num_fibers : int Atomic.t;
-  computation : (unit, [ `Await | `Cancel | `Return ]) Computation.t;
-}
+type t = { num_fibers : int Atomic.t; computation : unit Computation.t }
 
 let decr t =
   let n = Atomic.fetch_and_add t.num_fibers (-1) in

--- a/test/lib/elements/promise.mli
+++ b/test/lib/elements/promise.mli
@@ -8,7 +8,7 @@ type !'a t
 val await : 'a t -> 'a
 (** *)
 
-val of_computation : ('a, [> `Await | `Cancel ]) Picos.Computation.t -> 'a t
+val of_computation : 'a Picos.Computation.t -> 'a t
 (** *)
 
 val peek : 'a t -> 'a option

--- a/test/test_picos.ml
+++ b/test/test_picos.ml
@@ -24,8 +24,7 @@ let test_fls_basics =
 
   let counter_key =
     let counter = Atomic.make 0 in
-    (Fiber.FLS.new_key @@ Computed (fun () -> Atomic.fetch_and_add counter 1)
-      :> _ Fiber.FLS.as_read_only)
+    Fiber.FLS.new_key @@ Computed (fun () -> Atomic.fetch_and_add counter 1)
   in
 
   fun () ->


### PR DESCRIPTION
This PR drops the phantom type parameters previously used to document and statically enforce some of the constraints on when and by whom certain operations on `Trigger`s, `Computation`s, and `Fiber`s may be called.  While the phantom types do effectively prevent some mistakes, they have been seen as inconvenient #31.  Instead of using phantom type parameters, the constraints are now briefly documented as warnings (⚠️) in the documentation.