### PR TITLE
Add some more flesh to the documentation

### DIFF
--- a/lib/picos/default.ml
+++ b/lib/picos/default.ml
@@ -58,7 +58,7 @@ let await trigger =
       Bootstrap.Fiber.canceled per_thread.fiber
     end
   else begin
-    Bootstrap.Trigger.signal trigger;
+    Bootstrap.Trigger.dispose trigger;
     Bootstrap.Fiber.canceled per_thread.fiber
   end
 
@@ -244,8 +244,7 @@ let cancel_after seconds exn_bt computation =
       let id = Per_domain.next_id per_domain in
       Per_domain.add_timeout per_domain id entry;
       let remover =
-        Atomic.make
-          (Bootstrap.Trigger.Awaiting (Per_domain.remove_timeout, per_domain, id))
+        Bootstrap.Trigger.from_action per_domain id Per_domain.remove_timeout
       in
       if not (Bootstrap.Computation.try_attach computation remover) then
         Bootstrap.Trigger.signal remover

--- a/lib/picos/effects_intf.ocaml5.ml
+++ b/lib/picos/effects_intf.ocaml5.ml
@@ -29,7 +29,8 @@ module type Trigger = sig
       [resume] action to the [trigger].
 
       Whether being resumed due to cancelation or not, the trigger should be
-      signaled before resuming the fiber.
+      either {{!signal} signaled} outside of the effect handler, or {{!dispose}
+      disposed} by the effect handler, before resuming the fiber.
 
       The scheduler is free to choose which ready fiber to resume next. *)
   type _ Effect.t += private Await : t -> exn_bt option Effect.t


### PR DESCRIPTION
This also adds

- `Trigger.from_action` for special uses cases needed by schedulers, and

- `Trigger.dispose` for safer disposal of triggers inside schedulers.
