### PR TITLE
Add `alert` attributes to dangerous operations

### DIFF
--- a/test/lib/schedulers/fifos.ml
+++ b/test/lib/schedulers/fifos.ml
@@ -65,7 +65,7 @@ let run ~forbid main =
           Mpsc_queue.enqueue t.ready (Fiber.continue fiber k);
           next t)
     in
-    let effc (type a) :
+    let[@alert "-handler"] effc (type a) :
         a Effect.t -> ((a, _) Effect.Deep.continuation -> _) option = function
       | Fiber.Current ->
           (* We handle [Current] first as it is perhaps the most latency

--- a/test/test_picos.ml
+++ b/test/test_picos.ml
@@ -132,14 +132,14 @@ let test_computation_completion_signals_triggers_in_order () =
        let triggers = ref [] in
        let counter = ref 0 in
        let attach_one () =
-         let trigger = Trigger.create () in
-         triggers := trigger :: !triggers;
          let i = !counter in
          counter := i + 1;
-         assert (Computation.try_attach computation trigger);
-         assert (
-           Trigger.on_signal trigger () () (fun _ _ _ ->
-               signals := i :: !signals))
+         let[@alert "-sledge_hammer"] trigger =
+           Trigger.from_action signals i @@ fun _ signals i ->
+           signals := i :: !signals
+         in
+         triggers := trigger :: !triggers;
+         assert (Computation.try_attach computation trigger)
        in
        let detach_one () =
          let n = List.length !triggers in


### PR DESCRIPTION
The ability to attach a callback to a trigger is the one thing in Picos that must be done with care, because it basically allows you to cause an unknown execution context to call that callback synchronously.  Such callbacks should be written with extreme care.