### PR TITLE
Add `Fiber.try_suspend` and `Fiber.unsuspend` helpers

### DIFF
--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -1042,6 +1042,25 @@ module Fiber : sig
   val create : forbid:bool -> 'a Computation.t -> t
   (** [create ~forbid computation] creates a new fiber. *)
 
+  val try_suspend :
+    t -> Trigger.t -> 'x -> 'y -> (Trigger.t -> 'x -> 'y -> unit) -> bool
+  (** [try_suspend fiber trigger x y resume] tries to suspend the [fiber] to
+      await for the [trigger] to be {{!Trigger.signal} signaled}.  If the result
+      is [false], then the [trigger] is guaranteed to be in the signaled state
+      and the fiber should be eventually resumed.  If the result is [true], then
+      the fiber was suspended, meaning that the [trigger] will have had the
+      [resume] action {{!Trigger.on_signal} attached} to it and the trigger has
+      potentially been {{!Computation.try_attach} attached} to the
+      {!computation} of the fiber. *)
+
+  val unsuspend : t -> Trigger.t -> bool
+  (** [unsuspend fiber trigger] makes sure that the [trigger] will not be
+      attached to the computation of the [fiber].  Returns [false] in case the
+      fiber has been canceled and propagation of cancelation is not forbidden.
+      Otherwise returns [true].
+
+      ⚠️ The trigger must be in the signaled state! *)
+
   include
     Intf.Fiber
       with type t := t

--- a/lib/picos_fifos/picos_fifos.ml
+++ b/lib/picos_fifos/picos_fifos.ml
@@ -7,7 +7,6 @@ type ready =
   | Spawn of Fiber.t * (unit -> unit)
   | Continue of Fiber.t * (unit, unit) Effect.Deep.continuation
   | Resume of Fiber.t * (Exn_bt.t option, unit) Effect.Deep.continuation
-  | Resume_forbidden of (Exn_bt.t option, unit) Effect.Deep.continuation
 
 type t = {
   ready : ready Queue.t;
@@ -77,70 +76,10 @@ let rec next t =
                     Effect.Deep.continue k ()
                 | Some exn_bt -> Exn_bt.discontinue k exn_bt)
         | Trigger.Await trigger ->
-            (* We handle [Await] last as it is probably the least latency
-               sensitive effect.  It could also be that another fiber running in
-               parallel is just about to signal the trigger, so checking the
-               trigger last gives a tiny bit of time for that to happen and
-               potentially allows us to make better/different decisions here. *)
             Some
               (fun k ->
-                (* The non-blocking logic below for suspending a fiber with
-                   support for parallelism safe cancelation is somewhat
-                   intricate.  Hopefully the comments help to understand it. *)
-                if Fiber.has_forbidden fiber then begin
-                  (* Fiber has forbidden propagation of cancelation.  This is
-                     the easy case to handle. *)
-                  if Trigger.on_signal trigger fiber k t.resume then begin
-                    (* Fiber is now suspended and can be resumed through the
-                       trigger.  We just continue the next ready fiber. *)
-                    next t
-                  end
-                  else begin
-                    (* The trigger was already signaled.  We could now freely
-                       choose which fiber to continue here, but in this
-                       scheduler we choose to continue the current fiber. *)
-                    Effect.Deep.continue k None
-                  end
-                end
-                else begin
-                  (* Fiber permits propagation of cancelation.  We support
-                     cancelation and so first try to attach the trigger to the
-                     computation of the fiber. *)
-                  if Fiber.try_attach fiber trigger then begin
-                    (* The trigger was successfully attached, which means the
-                       computation has not been canceled. *)
-                    if Trigger.on_signal trigger fiber k t.resume then begin
-                      (* Fiber is now suspended and can be resumed through the
-                         trigger.  That can now happen by signaling the trigger
-                         directly or by canceling the computation of the fiber,
-                         which will also signal the trigger.  We just continue
-                         the next ready fiber. *)
-                      next t
-                    end
-                    else begin
-                      (* The trigger was already signaled.  We first need to
-                         ensure that the trigger is detached from the
-                         computation of the fiber. *)
-                      Fiber.detach fiber trigger;
-                      (* We could now freely decide which fiber to continue, but
-                         in this scheduler we choose to continue the current
-                         fiber. *)
-                      Fiber.resume fiber k
-                    end
-                  end
-                  else begin
-                    (* We could not attach the trigger to the computation of the
-                       fiber, which means that either the computation has been
-                       canceled or the trigger has been signaled.  We still need
-                       to ensure that the trigger really is put into the
-                       signaled state before the fiber is continued. *)
-                    Trigger.dispose trigger;
-                    (* We could now freely decide which fiber to continue, but
-                       in this scheduler we choose to continue the current
-                       fiber. *)
-                    Fiber.resume fiber k
-                  end
-                end)
+                if Fiber.try_suspend fiber trigger fiber k t.resume then next t
+                else Fiber.resume fiber k)
         | _ -> None
       and retc () =
         Atomic.decr t.num_alive_fibers;
@@ -149,7 +88,6 @@ let rec next t =
       Effect.Deep.match_with main () { retc; exnc = raise; effc }
   | Continue (fiber, k) -> Fiber.continue fiber k ()
   | Resume (fiber, k) -> Fiber.resume fiber k
-  | Resume_forbidden k -> Effect.Deep.continue k None
   | exception Queue.Empty ->
       if Atomic.get t.num_alive_fibers <> 0 then begin
         if Atomic.get t.needs_wakeup then begin
@@ -171,33 +109,14 @@ let run ~forbid main =
   and mc = Picos_ptmc.get () in
   let rec t = { ready; needs_wakeup; num_alive_fibers; mc; resume }
   and resume trigger fiber k =
-    begin
-      if Fiber.has_forbidden fiber then
-        (* Fiber has forbidden propagation of cancelation.  This is the easy
-           case. *)
-        Queue.push t.ready (Resume_forbidden k)
-      else
-        let resume = Resume (fiber, k) in
-        if Fiber.is_canceled fiber then begin
-          (* The fiber has been canceled so we give priority to it in this
-             scheduler.
-
-             Assuming fibers are written to cooperate and perform cleanup
-             promptly, this can be advantageous as it allows resources to be
-             released more quickly.  However, malicious or buggy fibers could
-             use this to prevent other fibers from running. *)
-          Queue.push_head t.ready resume
-        end
-        else begin
-          (* The fiber hasn't yet been canceled.
-
-             As propagation of cancelation was not forbidden, and we have
-             attached a trigger, we need to ensure that the trigger will not be
-             leaked. *)
-          Fiber.detach fiber trigger;
-          Queue.push t.ready resume
-        end
-    end;
+    let resume = Resume (fiber, k) in
+    if Fiber.unsuspend fiber trigger then
+      (* The fiber has not been canceled, so we queue the fiber normally. *)
+      Queue.push t.ready resume
+    else
+      (* The fiber has been canceled, so we give priority to it in this
+         scheduler. *)
+      Queue.push_head t.ready resume;
     (* As the trigger might have been signaled from another domain or systhread
        outside of the scheduler, we check whether the scheduler needs to be
        woken up and take care of it if necessary. *)


### PR DESCRIPTION
I noticed I had failed to account for one case in my previous `await` handler implementations. 😞

This fixes that by introducing a pair of helpers for suspending and unsuspending a fiber. 😌