### PR TITLE
Add interrupt support and implement async IO for blocking FDs

### DIFF
--- a/lib/picos_select/dune
+++ b/lib/picos_select/dune
@@ -8,6 +8,7 @@
   (re_export picos.fd)
   (re_export unix)
   picos.domain
+  picos.tls
   picos_thread_atomic
   threads.posix
   psq

--- a/lib/picos_stdio/dune
+++ b/lib/picos_stdio/dune
@@ -5,4 +5,5 @@
  (libraries
   (re_export unix)
   (re_export picos.fd)
+  picos.htbl
   picos.select))

--- a/lib/picos_stdio/picos_stdio.mli
+++ b/lib/picos_stdio/picos_stdio.mli
@@ -1,27 +1,22 @@
-(** Basic IO facilities based on OCaml standard libraries for {!Picos}.
-
-    🚧 This library is currently considered experimental and unfinished.  Please
-    report any problems and issues you might encounter. *)
+(** Basic IO facilities based on OCaml standard libraries for {!Picos}. *)
 
 module Unix : sig
   (** A transparently asynchronous replacement for a subset of the {{!Deps.Unix}
       [Unix]} module that comes with OCaml.
 
-      All the operations in this module that return file descriptors implicitly
-      set the {{!file_descr} file descriptors} to {{!Deps.Unix.set_nonblock}
-      non-blocking mode} and operations on file descriptors, such as {!read} and
+      In this module operations on file descriptors, such as {!read} and
       {!write} and others, implicitly block, in a scheduler friendly manner, to
-      await for the file descriptor to become available for the operation.
+      await for the file descriptor to become available for the operation.  This
+      works best with file descriptors {{!set_nonblock} set to non-blocking mode}.
 
       ⚠️ Beware that this does not currently try to work around any limitations
-      of the {{!Deps.Unix} [Unix]} module that comes with OCaml.  For example,
-      on Windows, only sockets can be put into non-blocking mode.
+      of the {{!Deps.Unix} [Unix]} module that comes with OCaml.  In particular,
+      on Windows, only sockets can be put into non-blocking mode.  Also, on
+      Windows, scheduler friendly blocking only works properly with non-blocking
+      file descriptors, i.e. sockets.
 
       Please consult the documentation of the {{!Deps.Unix} [Unix]} module that
-      comes with OCaml.
-
-      🚧 This module is currently considered experimental and unfinished.
-      Please report any problems and issues you might encounter. *)
+      comes with OCaml. *)
 
   type file_descr = Picos_fd.t
   (** Opaque type alias for {{!Deps.Unix.file_descr} [Unix.file_descr]}.
@@ -259,10 +254,8 @@ module Unix : sig
   val access : string -> access_permission list -> unit
   val dup : ?cloexec:bool -> file_descr -> file_descr
   val dup2 : ?cloexec:bool -> file_descr -> file_descr -> unit
-
-  (*val set_nonblock : file_descr -> unit*)
-  (*val clear_nonblock : file_descr -> unit*)
-
+  val set_nonblock : file_descr -> unit
+  val clear_nonblock : file_descr -> unit
   val set_close_on_exec : file_descr -> unit
   val clear_close_on_exec : file_descr -> unit
   val mkdir : string -> file_perm -> unit

--- a/test/dune
+++ b/test/dune
@@ -56,6 +56,13 @@
 ;;
 
 (test
+ (name test_select)
+ (modules test_select)
+ (libraries picos.threaded picos.select alcotest domain_shims))
+
+;;
+
+(test
  (name test_mpsc_queue)
  (package picos)
  (modules test_mpsc_queue)

--- a/test/test_select.ml
+++ b/test/test_select.ml
@@ -1,0 +1,37 @@
+open Picos
+
+let test_intr () =
+  let inn, out = Unix.pipe ~cloexec:true () in
+  let main () =
+    Picos_threaded.run ~forbid:false @@ fun () ->
+    let computation = Computation.create () in
+    let n_threads = 10 in
+    let n = Atomic.make n_threads in
+    for _ = 1 to n_threads do
+      let main () =
+        for _ = 1 to 1_000 do
+          let req = Picos_select.Intr.req ~seconds:0.000_001 in
+          match Unix.read inn (Bytes.create 1) 0 1 with
+          | _ -> assert false
+          | exception Unix.Unix_error (EINTR, _, _) -> Picos_select.Intr.clr req
+        done;
+        if 1 = Atomic.fetch_and_add n (-1) then Computation.finish computation
+      in
+      Fiber.spawn ~forbid:false computation [ main ]
+    done;
+    Computation.wait computation
+  in
+  let domains = Array.init 3 @@ fun _ -> Domain.spawn main in
+  let finally () =
+    Array.iter Domain.join domains;
+    Unix.close inn;
+    Unix.close out
+  in
+  Fun.protect ~finally main
+
+let () =
+  [
+    ( "Intr",
+      if Sys.win32 then [] else [ Alcotest.test_case "" `Quick test_intr ] );
+  ]
+  |> Alcotest.run "Picos_select"


### PR DESCRIPTION
This PR
- enhances `Picos_stdio` to handle `EINTR` errors by retrying the computation,
- adds support for "interrupts" into `Picos_select` that generate signals, and
- uses the interrupt support for transparently asynchronous IO with blocking FDs.
