### PR TITLE
Add `Picos_stdio` benchmark

### DIFF
--- a/bench/bench_cancel_after.ml
+++ b/bench/bench_cancel_after.ml
@@ -32,7 +32,8 @@ let run_round_trip ~budgetf ~n_domains () =
   let config =
     Printf.sprintf "%d worker%s" n_domains (if n_domains = 1 then "" else "s")
   in
-  Times.record ~budgetf ~n_domains ~init ~wrap ~work ()
+  Times.record ~budgetf ~n_domains ~init ~n_warmups:1 ~n_runs_min:1 ~wrap ~work
+    ()
   |> Times.to_thruput_metrics ~n:n_ops ~singular:"round-trip" ~config
 
 let run_async ~budgetf ~n_domains () =
@@ -81,7 +82,8 @@ let run_async ~budgetf ~n_domains () =
   let config =
     Printf.sprintf "%d worker%s" n_domains (if n_domains = 1 then "" else "s")
   in
-  Times.record ~budgetf ~n_domains ~init ~wrap ~work ()
+  Times.record ~budgetf ~n_domains ~n_warmups:1 ~n_runs_min:1 ~init ~wrap ~work
+    ()
   |> Times.to_thruput_metrics ~n:n_ops ~singular:"async round-trip" ~config
 
 let run_suite ~budgetf =

--- a/bench/bench_mutex.ml
+++ b/bench/bench_mutex.ml
@@ -65,7 +65,8 @@ let run_one ~budgetf ~n_fibers ~use_domains () =
       (if use_domains then "domain" else "fiber")
       (if n_fibers = 1 then "" else "s")
   in
-  Times.record ~budgetf ~n_domains ~init ~wrap ~work ()
+  Times.record ~budgetf ~n_domains ~n_warmups:1 ~n_runs_min:1 ~init ~wrap ~work
+    ()
   |> Times.to_thruput_metrics ~n:n_ops ~singular:"locked yield" ~config
 
 let run_suite ~budgetf =

--- a/bench/bench_spawn.ml
+++ b/bench/bench_spawn.ml
@@ -26,7 +26,8 @@ let run_one ~budgetf ~at_a_time () =
   in
 
   let config = Printf.sprintf "%d at a time" at_a_time in
-  Times.record ~budgetf ~n_domains:1 ~init ~wrap ~work ()
+  Times.record ~budgetf ~n_domains:1 ~n_warmups:1 ~n_runs_min:1 ~init ~wrap
+    ~work ()
   |> Times.to_thruput_metrics ~n:n_spawns ~singular:"spawn" ~config
 
 let run_suite ~budgetf =

--- a/bench/bench_stdio.ml
+++ b/bench/bench_stdio.ml
@@ -1,0 +1,53 @@
+open Multicore_bench
+open Picos_stdio
+
+let run_one ~budgetf ~block_or_nonblock ~n_domains () =
+  let n_bytes =
+    match block_or_nonblock with `Block -> 4096 | `Nonblock -> 65536
+  in
+
+  let init _ =
+    let inn, out = Unix.pipe ~cloexec:true () in
+    (inn, out, Bytes.create 1)
+  in
+  let wrap _ _ = Scheduler.run in
+  let work _ (inn, out, byte) =
+    begin
+      match block_or_nonblock with
+      | `Block -> ()
+      | `Nonblock -> Unix.set_nonblock inn
+    end;
+    let n = Unix.write out (Bytes.create n_bytes) 0 n_bytes in
+    assert (n = n_bytes);
+    for _ = 1 to n_bytes do
+      let n : int = Unix.read inn byte 0 1 in
+      assert (n = 1)
+    done;
+    Unix.close inn;
+    Unix.close out
+  in
+
+  let times =
+    Times.record ~budgetf ~n_domains ~n_warmups:1 ~n_runs_min:1 ~init ~wrap
+      ~work ()
+  in
+
+  let config =
+    Printf.sprintf "%d worker%s" n_domains (if n_domains = 1 then "" else "s")
+  and singular =
+    match block_or_nonblock with
+    | `Block -> "blocking read"
+    | `Nonblock -> "non-blocking read"
+  in
+  Times.to_thruput_metrics ~n:(n_bytes * n_domains) ~singular ~config times
+
+let run_suite ~budgetf =
+  Util.cross [ `Nonblock; `Block ] [ 1; 2; 4 ]
+  |> List.concat_map @@ fun (block_or_nonblock, n_domains) ->
+     if
+       Sys.win32
+       || Picos_domain.recommended_domain_count () < n_domains
+       || String.starts_with ~prefix:"5.0." Sys.ocaml_version
+          && block_or_nonblock == `Block
+     then []
+     else run_one ~budgetf ~block_or_nonblock ~n_domains ()

--- a/bench/bench_yield.ml
+++ b/bench/bench_yield.ml
@@ -27,7 +27,8 @@ let run_one ~budgetf ~n_fibers () =
   let config =
     Printf.sprintf "%d fiber%s" n_fibers (if n_fibers = 1 then "" else "s")
   in
-  Times.record ~budgetf ~n_domains:1 ~init ~wrap ~work ()
+  Times.record ~budgetf ~n_domains:1 ~n_warmups:1 ~n_runs_min:1 ~init ~wrap
+    ~work ()
   |> Times.to_thruput_metrics ~n:n_yields ~singular:"yield" ~config
 
 let run_suite ~budgetf =

--- a/bench/dune
+++ b/bench/dune
@@ -10,6 +10,7 @@
   picos.sync
   picos.domain
   picos.tls
+  picos.stdio
   (select
    scheduler.ml
    from

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -12,6 +12,7 @@ let benchmarks =
     ("Ref with Picos_sync.Mutex", Bench_ref_mutex.run_suite);
     ("Foundation Mpsc_queue", Bench_mpsc_queue.run_suite);
     ("Picos_htbl", Bench_htbl.run_suite);
+    ("Picos_stdio", Bench_stdio.run_suite);
   ]
 
 let () = Multicore_bench.Cmd.run ~benchmarks ()

--- a/lib/picos_select/dune
+++ b/lib/picos_select/dune
@@ -10,6 +10,7 @@
   picos.domain
   picos.tls
   picos_thread_atomic
+  backoff
   threads.posix
   psq
   mtime

--- a/test/test_select.ml
+++ b/test/test_select.ml
@@ -32,6 +32,8 @@ let test_intr () =
 let () =
   [
     ( "Intr",
-      if Sys.win32 then [] else [ Alcotest.test_case "" `Quick test_intr ] );
+      if Sys.win32 || String.starts_with ~prefix:"5.0." Sys.ocaml_version then
+        []
+      else [ Alcotest.test_case "" `Quick test_intr ] );
   ]
   |> Alcotest.run "Picos_select"


### PR DESCRIPTION
This adds a minimal benchmark that tries to measure the overheads that `Picos_select` imposes and fine tunes some of the interrupt handling code a bit for performance &mdash; there is still room to improve.

This PR also enhances the atomicity of the interrupt handling by ensuring that the number of pending interrupts is updated in a linearizable manner.