### PR TITLE
Support `Unix.wait` and related functions in `Picos_stdio`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Next version
 
+- Scheduler friendly `waitpid`, `wait`, and `system` in `Picos_stdio.Unix` for
+  platforms other than Windows (@polytypic)
 - Added `Picos_select.configure` to allow, and sometimes require, configuring
   `Picos_select` for co-operation with libraries that also deal with signals
   (@polytypic)

--- a/lib/picos_select/dune
+++ b/lib/picos_select/dune
@@ -9,6 +9,7 @@
   (re_export unix)
   picos.domain
   picos.thread
+  picos.htbl
   picos_thread_atomic
   backoff
   threads.posix

--- a/lib/picos_select/picos_select.mli
+++ b/lib/picos_select/picos_select.mli
@@ -70,14 +70,30 @@ module Intr : sig
       {!req} must be cleared exactly once! *)
 end
 
+(** {1 Processes} *)
+
+val return_on_sigchld : 'a Computation.t -> 'a -> unit
+(** [return_on_sigchld computation value] arranges for [computation] to be
+    {{!Picos.Computation.return} returned} with given [value] on next
+    {!Sys.sigchld}.  Completion of the [computation] before a {!Sys.sigchld} is
+    received effectively cancels the arrangement.
+
+    ⚠️ The mechanism uses the {!Sys.sigchld} signal which should not be used for
+    other purposes. *)
+
 (** {1 Configuration} *)
 
-val configure : ?intr_sig:int -> unit -> unit
-(** [configure ~intr_sig ()] can, and sometimes must, be called by an
-    application to configure the use of signals by this module.
+val configure : ?intr_sig:int -> ?handle_sigchld:bool -> unit -> unit
+(** [configure ~intr_sig ~handle_sigchld ()] can, and sometimes must, be called
+    by an application to configure the use of signals by this module.
 
     The optional [intr_sig] argument can be used to specify the signal used by
     the {{!Intr} interrupt} mechanism.  The default is to use {!Sys.sigusr2}.
+
+    The optional [handle_sigchld] argument can be used to specify whether this
+    module should setup handling of {!Sys.sigchld}.  The default is [true].
+    When explicitly specified as [~handle_sigchld:false], the application should
+    arrange to call {!handle_signal} whenever a {!Sys.sigchld} signal occurs.
 
     ⚠️ This module must always be configured before use.  Unless this module has
     been explicitly configured, calling a method of this module from the main

--- a/lib/picos_stdio/picos_stdio.mli
+++ b/lib/picos_stdio/picos_stdio.mli
@@ -27,7 +27,13 @@ module Unix : sig
       - {!sleep}, and
       - {!sleepf}
 
-      also block in a scheduler friendly manner.
+      also block in a scheduler friendly manner.  Additionally
+
+      - {!wait},
+      - {!waitpid}, and
+      - {!system}
+
+      also block in a scheduler friendly manner except on Windows.
 
       ⚠️ This module uses {!Picos_select} and you may need to
       {{!Picos_select.configure} configure} it at start of your application.
@@ -144,11 +150,9 @@ module Unix : sig
   val execvp : string -> string array -> 'a
   val execvpe : string -> string array -> string array -> 'a
   val fork : unit -> int
-
-  (*val wait : unit -> int * process_status*)
-  (*val waitpid : wait_flag list -> int -> int * process_status*)
-  (*val system : string -> process_status*)
-
+  val wait : unit -> int * process_status
+  val waitpid : wait_flag list -> int -> int * process_status
+  val system : string -> process_status
   val _exit : int -> 'a
   val getpid : unit -> int
   val getppid : unit -> int

--- a/test/dune
+++ b/test/dune
@@ -53,6 +53,13 @@
 ;;
 
 (test
+ (name test_stdio)
+ (modules test_stdio)
+ (libraries test_scheduler picos.stdio alcotest))
+
+;;
+
+(test
  (name test_select)
  (modules test_select)
  (libraries picos.threaded picos.select alcotest domain_shims))

--- a/test/test_stdio.ml
+++ b/test/test_stdio.ml
@@ -1,0 +1,18 @@
+open Picos_stdio
+
+let test_system_unix () =
+  Test_scheduler.run @@ fun () ->
+  assert (Unix.system "exit 101" = Unix.WEXITED 101);
+  assert (Unix.system "echo Hello world!" = Unix.WEXITED 0);
+  assert (Unix.system "this-is-not-supposed-to-exist" = Unix.WEXITED 127);
+  match Unix.wait () with
+  | _ -> assert false
+  | exception Unix.Unix_error (ECHILD, _, _) -> ()
+
+let () =
+  [
+    ( "Unix",
+      if Sys.win32 then []
+      else [ Alcotest.test_case "system" `Quick test_system_unix ] );
+  ]
+  |> Alcotest.run "Picos_stdio"


### PR DESCRIPTION
This PR adds support for scheduler friendly `Unix.waitpid`, `Unix.wait`, and `Unix.system` on non-Windows platforms.

On Windows I see no way to provide those in a non-blocking fashion (using only the OCaml standard libraries) except by spawning threads and for that a thread pool would make a lot of sense.  So, I'm leaving that for future work.