### PR TITLE
Make `Picos_select` explicitly configurable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,11 @@
 ## Next version
 
+- Added `Picos_select.configure` to allow, and sometimes require, configuring
+  `Picos_select` for co-operation with libraries that also deal with signals
+  (@polytypic)
 - Moved `Picos_tls` into `Picos_thread.TLS` (@polytypic)
 - Enhanced `sleep` and `sleepf` in `Picos_stdio.Unix` to block in a scheduler
-  friendly manner (@polytypic).
+  friendly manner (@polytypic)
 
 ## 0.1.0
 

--- a/lib/picos_fifos/picos_fifos.ml
+++ b/lib/picos_fifos/picos_fifos.ml
@@ -104,6 +104,7 @@ let rec next t =
       end
 
 let run ~forbid main =
+  Select.check_configured ();
   let ready = Queue.create ()
   and needs_wakeup = Atomic.make false
   and num_alive_fibers = Atomic.make 1

--- a/lib/picos_fifos/select.none.ml
+++ b/lib/picos_fifos/select.none.ml
@@ -1,2 +1,4 @@
 let cancel_after _ ~seconds:_ _ =
   raise (Sys_error "Computation: cancel_after unavailable")
+
+let check_configured = Fun.id

--- a/lib/picos_fifos/select.some.ml
+++ b/lib/picos_fifos/select.some.ml
@@ -1,1 +1,2 @@
 let cancel_after = Picos_select.cancel_after
+let check_configured = Picos_select.check_configured

--- a/lib/picos_stdio/picos_stdio.mli
+++ b/lib/picos_stdio/picos_stdio.mli
@@ -29,6 +29,9 @@ module Unix : sig
 
       also block in a scheduler friendly manner.
 
+      ⚠️ This module uses {!Picos_select} and you may need to
+      {{!Picos_select.configure} configure} it at start of your application.
+
       Please consult the documentation of the {{!Deps.Unix} [Unix]} module that
       comes with OCaml. *)
 

--- a/lib/picos_threaded/picos_threaded.ml
+++ b/lib/picos_threaded/picos_threaded.ml
@@ -83,4 +83,5 @@ and spawn : type a. _ -> forbid:bool -> a Computation.t -> _ =
 and handler = Handler.{ current; spawn; yield; cancel_after; await }
 
 let run ~forbid main =
+  Select.check_configured ();
   Handler.using handler (create ~forbid (Computation.create ())) main

--- a/lib/picos_threaded/select.none.ml
+++ b/lib/picos_threaded/select.none.ml
@@ -1,2 +1,4 @@
 let cancel_after _ ~seconds:_ _ =
   raise (Sys_error "Computation: cancel_after unavailable")
+
+let check_configured = Fun.id

--- a/lib/picos_threaded/select.some.ml
+++ b/lib/picos_threaded/select.some.ml
@@ -1,1 +1,2 @@
 let cancel_after = Picos_select.cancel_after
+let check_configured = Picos_select.check_configured

--- a/test/test_select.ml
+++ b/test/test_select.ml
@@ -1,5 +1,7 @@
 open Picos
 
+let () = Picos_select.configure ()
+
 let test_intr () =
   let inn, out = Unix.pipe ~cloexec:true () in
   let main () =


### PR DESCRIPTION
This PR makes `Picos_select` configurable.  The configurability is really mostly needed by the changes in #91 but moving this into a separate PR hopefully makes the individual changes easier to understand.