### PR TITLE
When `threads.posix` exists we really need `thread-local-storage`

### DIFF
--- a/lib/picos_thread/dune
+++ b/lib/picos_thread/dune
@@ -13,7 +13,7 @@
    tls.ml
    from
    (thread-local-storage -> tls.thread-local-storage.ml)
-   (picos.domain -> tls.dls.ml))))
+   (picos.domain !threads.posix -> tls.dls.ml))))
 
 (rule
  (enabled_if


### PR DESCRIPTION
`thread-local-storage` is needed for correct operation when `threads.posix` exists.  TLS is used to store the fiber identity with `picos.threaded` and that breaks without proper TLS.

I've now run into this a couple of times that I missed `thread-local-storage` from the switch and that unfortunately allowed an invalid build where `threads.posix` (and hence systhreads) existed without `thread-local-storage`.