### PR TITLE
Enable tests on Win32

### DIFF
--- a/test/test_stdio.md
+++ b/test/test_stdio.md
@@ -13,7 +13,7 @@ test_stdio.md
 - : Unix.process_status = Picos_stdio.Unix.WEXITED 0
 ```
 
-```ocaml os_type<>Win32
+```ocaml
 # Test_scheduler.run @@ fun () ->
   let@ fd =
     finally Unix.close @@ fun () ->


### PR DESCRIPTION
Enable openfile and read test on Win32.  Operations on files are essentially
non-blocking.

Using sockets we can also do non-blocking IO on Windows.
