### PR TITLE
Make the forbid argument optional in sample schedulers

### DIFF
--- a/bench/scheduler.ocaml4.ml
+++ b/bench/scheduler.ocaml4.ml
@@ -1,1 +1,1 @@
-let run main = Picos_threaded.run ~forbid:false main
+let run main = Picos_threaded.run main

--- a/bench/scheduler.ocaml5.ml
+++ b/bench/scheduler.ocaml5.ml
@@ -1,1 +1,1 @@
-let run main = Picos_fifos.run ~forbid:false main
+let run main = Picos_fifos.run main

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -121,16 +121,13 @@
     and define a simple scheduler on OCaml 4
 
     {@ocaml version<5.0.0[
-      let run main =
-        Picos_threaded.run
-          ~forbid:false main
+      let run main = Picos_threaded.run main
     ]}
 
     using {{!Picos_threaded} the basic thread based scheduler} and on OCaml 5
 
     {@ocaml version>=5.0.0[
-      let run main =
-        Picos_fifos.run ~forbid:false main
+      let run main = Picos_fifos.run main
     ]}
 
     using {{!Picos_fifos} the basic effects based scheduler} that come with

--- a/lib/picos_fifos/picos_fifos.ml
+++ b/lib/picos_fifos/picos_fifos.ml
@@ -103,7 +103,7 @@ let rec next t =
         next t
       end
 
-let run ~forbid main =
+let run ?(forbid = false) main =
   Select.check_configured ();
   let ready = Queue.create ()
   and needs_wakeup = Atomic.make false

--- a/lib/picos_fifos/picos_fifos.mli
+++ b/lib/picos_fifos/picos_fifos.mli
@@ -22,6 +22,9 @@
     This scheduler also gives priority to fibers woken up from
     {{!Picos.Trigger.await} [await]} due to being canceled. *)
 
-val run : forbid:bool -> (unit -> 'a) -> 'a
-(** [run ~forbid main] runs the [main] thunk with the scheduler.  Returns after
-    [main] and all of the fibers spawned by [main] have returned. *)
+val run : ?forbid:bool -> (unit -> 'a) -> 'a
+(** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
+    and all of the fibers spawned by [main] have returned.
+
+    The optional [forbid] argument defaults to [false] and determines whether
+    propagation of cancelation is initially allowed. *)

--- a/lib/picos_lwt/intf.ml
+++ b/lib/picos_lwt/intf.ml
@@ -9,10 +9,13 @@ end
 module type S = sig
   (** Direct style {!Picos} compatible interface to {!Lwt}. *)
 
-  val run : forbid:bool -> (unit -> 'a) -> 'a Lwt.t
-  (** [run ~forbid main] runs the [main] program implemented in {!Picos} as a
-      promise with {!Lwt} as the scheduler.  In other words, the [main] program
-      will be run as a {!Lwt} promise or fiber. *)
+  val run : ?forbid:bool -> (unit -> 'a) -> 'a Lwt.t
+  (** [run main] runs the [main] program implemented in {!Picos} as a promise
+      with {!Lwt} as the scheduler.  In other words, the [main] program will be
+      run as a {!Lwt} promise or fiber.
+
+      The optional [forbid] argument defaults to [false] and determines whether
+      propagation of cancelation is initially allowed. *)
 
   val await : (unit -> 'a Lwt.t) -> 'a
   (** [await thunk] awaits for the promise returned by [thunk ()] to resolve and

--- a/lib/picos_lwt/picos_lwt.ml
+++ b/lib/picos_lwt/picos_lwt.ml
@@ -69,7 +69,7 @@ module Make (Sleep : Sleep) : S = struct
     | Ok v -> Effect.Shallow.continue_with k v handler
     | Error exn_bt -> Exn_bt.discontinue_with k exn_bt handler
 
-  let run ~forbid main =
+  let run ?(forbid = false) main =
     let computation = Computation.create () in
     let fiber = Fiber.create ~forbid computation in
     run fiber (Effect.Shallow.fiber main) (Ok ())

--- a/lib/picos_select/picos_select.mli
+++ b/lib/picos_select/picos_select.mli
@@ -136,7 +136,7 @@ val check_configured : unit -> unit
       # exception Timeout
       exception Timeout
 
-      # Picos_fifos.run ~forbid:false @@ fun () ->
+      # Picos_fifos.run @@ fun () ->
 
         let@ msg_inn1, msg_out1 =
           finally Unix.close_pair @@ fun () ->

--- a/lib/picos_stdio/picos_stdio.mli
+++ b/lib/picos_stdio/picos_stdio.mli
@@ -699,7 +699,7 @@ end
     pipes:
 
     {[
-      # Picos_fifos.run ~forbid:false @@ fun () ->
+      # Picos_fifos.run @@ fun () ->
 
         let@ msg_inn, msg_out =
           finally Unix.close_pair @@ fun () ->

--- a/lib/picos_structured/picos_structured.mli
+++ b/lib/picos_structured/picos_structured.mli
@@ -297,7 +297,7 @@ end
     Finally we run the main program with a scheduler:
 
     {[
-      # Picos_fifos.run ~forbid:false main
+      # Picos_fifos.run main
       Received: Hello!
       Received: Hello!
       Received: Hello!

--- a/lib/picos_sync/picos_sync.mli
+++ b/lib/picos_sync/picos_sync.mli
@@ -232,7 +232,7 @@ end
     but we can now demonstrate it with the cooperative {!Picos_fifos} scheduler:
 
     {[
-      # Picos_fifos.run ~forbid:false @@ fun () ->
+      # Picos_fifos.run @@ fun () ->
 
         let bq =
           Bounded_q.create ~capacity:3

--- a/lib/picos_threaded/picos_threaded.ml
+++ b/lib/picos_threaded/picos_threaded.ml
@@ -83,7 +83,7 @@ and spawn : type a. _ -> forbid:bool -> a Computation.t -> _ =
 
 and handler = Handler.{ current; spawn; yield; cancel_after; await }
 
-let run ~forbid main =
+let run ?(forbid = false) main =
   Select.check_configured ();
   let packed = Computation.Packed (Computation.create ()) in
   Handler.using handler (create_packed ~forbid packed) main

--- a/lib/picos_threaded/picos_threaded.mli
+++ b/lib/picos_threaded/picos_threaded.mli
@@ -24,6 +24,9 @@
     OCaml 5 a scheduler that implements an effect handler directly is likely to
     perform better. *)
 
-val run : forbid:bool -> (unit -> 'a) -> 'a
-(** [run ~forbid main] runs the [main] thunk with the scheduler.  Returns after
-    [main] and all of the fibers spawned by [main] have returned. *)
+val run : ?forbid:bool -> (unit -> 'a) -> 'a
+(** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
+    and all of the fibers spawned by [main] have returned.
+
+    The optional [forbid] argument defaults to [false] and determines whether
+    propagation of cancelation is initially allowed. *)

--- a/test/test_lwt_unix.ml
+++ b/test/test_lwt_unix.ml
@@ -2,8 +2,7 @@ open Picos
 module Picos_lwt_unix = Picos_lwt.Make (Lwt_unix)
 
 let basics () =
-  Lwt_main.run
-  @@ Picos_lwt_unix.run ~forbid:false
+  Lwt_main.run @@ Picos_lwt_unix.run
   @@ fun () ->
   let computation = Computation.create () in
   let child =

--- a/test/test_scheduler.ocaml4.ml
+++ b/test/test_scheduler.ocaml4.ml
@@ -1,1 +1,1 @@
-let run ?(forbid = false) main = Picos_threaded.run ~forbid main
+let run ?forbid main = Picos_threaded.run ?forbid main

--- a/test/test_scheduler.ocaml5.ml
+++ b/test/test_scheduler.ocaml5.ml
@@ -1,1 +1,1 @@
-let run ?(forbid = false) main = Picos_fifos.run ~forbid main
+let run ?forbid main = Picos_fifos.run ?forbid main

--- a/test/test_select.ml
+++ b/test/test_select.ml
@@ -11,7 +11,7 @@ let test_intr () =
     @@ Unix.pipe ~cloexec:true
   in
   let main () =
-    Picos_threaded.run ~forbid:false @@ fun () ->
+    Picos_threaded.run @@ fun () ->
     let computation = Computation.create () in
     let n_threads = 10 in
     let n = Atomic.make n_threads in


### PR DESCRIPTION
It still makes sense to require the fiber operations to have it mandatory, because those are not user level operations and should be as fast as possible.