### PR TITLE
Change `Picos_structured.Run.any []` to not block

### DIFF
--- a/lib/picos_structured/picos_structured.mli
+++ b/lib/picos_structured/picos_structured.mli
@@ -242,16 +242,26 @@ module Run : sig
   (** Operations for running fibers in specific patterns. *)
 
   val all : (unit -> unit) list -> unit
-  (** [all actions] starts all the actions as separate fibers and waits until
-      they all complete. *)
+  (** [all actions] starts the actions as separate fibers and waits until they
+      all complete or one of them raises an unhandled exception other than
+      {{!Control.Terminate} [Terminate]}, which is not counted as an error,
+      after which the remaining fibers will be canceled.
+
+      ⚠️ It is not guaranteed that any of the actions in the list are called.  In
+      particular, after any action raises an unhandled exception or after the
+      main fiber is canceled, the actions that have not yet started may be
+      skipped entirely. *)
 
   val any : (unit -> unit) list -> unit
-  (** [any actions] starts all the actions as separate fibers and waits until at
-      least one of them completes.  The rest of the started fibers will then be
-      canceled.
+  (** [any actions] starts the actions as separate fibers and waits until one of
+      them completes or raises an unhandled exception other than
+      {{!Control.Terminate} [Terminate]}, which is not counted as an error,
+      after which the rest of the started fibers will be canceled.
 
-      ⚠️ Calling [any []] is equivalent to calling
-      {{!Control.block} [block ()]}. *)
+      ⚠️ It is not guaranteed that any of the actions in the list are called.  In
+      particular, after the first action returns successfully or after any
+      action raises an unhandled exception or after the main fiber is canceled,
+      the actions that have not yet started may be skipped entirely. *)
 end
 
 (** {1 Examples}

--- a/lib/picos_structured/run.ml
+++ b/lib/picos_structured/run.ml
@@ -2,13 +2,11 @@ let all actions =
   Bundle.join_after @@ fun bundle -> List.iter (Bundle.fork bundle) actions
 
 let any actions =
-  if actions == [] then Control.block ()
-  else
-    Bundle.join_after @@ fun bundle ->
-    try
-      actions
-      |> List.iter @@ fun action ->
-         Bundle.fork bundle @@ fun () ->
-         action ();
-         Bundle.terminate bundle
-    with Control.Terminate -> ()
+  Bundle.join_after @@ fun bundle ->
+  try
+    actions
+    |> List.iter @@ fun action ->
+       Bundle.fork bundle @@ fun () ->
+       action ();
+       Bundle.terminate bundle
+  with Control.Terminate -> ()

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -199,9 +199,9 @@ let test_any_and_all_errors () =
 let test_any_and_all_returns () =
   [ 0; 1; 2 ]
   |> List.iter @@ fun n_terminates ->
-     [ 1; 2 ]
+     [ 0; 1; 2 ]
      |> List.iter @@ fun n_incr ->
-        [ (Run.all, n_incr, n_incr); (Run.any, 1, n_incr) ]
+        [ (Run.all, n_incr, n_incr); (Run.any, Int.min 1 n_incr, n_incr) ]
         |> List.iter @@ fun (run_op, min, max) ->
            Test_scheduler.run @@ fun () ->
            let count = Atomic.make 0 in


### PR DESCRIPTION
There are a number of reasons for making this change.

While it sort of makes logical sense to block on an empty list, that can also be surprising and undesirable.  This has also come up as an opinion in private communications.

For example, suppose you want to use `Run.any` to start actions to try to search for a solution concurrently and the list of actions to use in the search is dynamically created.  A simple program such as

```ocaml
let solution = Atomic.make None in
...
Run.any search_actions;
match Atomic.get solution with
| None -> ...
| Some solution -> ...
```

might unexpectedly block in case the list of actions would be empty.

The above also illustrates that it is typically not difficult to implement the blocking semantics on top of the non-blocking semantics (i.e. just block in the `None` case).

It is still allowed to cancel individual fibers started with `Run.any`. Consider

```ocaml
Run.any []
```

and

```ocaml
Run.any [ fun () -> raise Control.Terminate ]
```

Is there a difference between the two?  Should both block and, if so, does that open more possibilities to write unexpectedly blocking code?

OTOH, disallowing canceling fibers used with `Run.any` (and `Run.all`) by raising `Control.Terminate` would seem to introduce an inconsistency with respect to other constructs in `Picos_structured`.

I'm happy to revisit this later in case more motivating examples arise.