### PR TITLE
Try to reproduce SIGSEGV

### DIFF
--- a/test/test_scheduler.ocaml5.ml
+++ b/test/test_scheduler.ocaml5.ml
@@ -1,6 +1,6 @@
 open Picos_structured.Finally
 
-let use_randos = Random.bool (Random.self_init ())
+let use_randos = Random.bool (Random.self_init ()) && false
 
 let run ?(max_domains = 1) ?forbid main =
   if use_randos then

--- a/test/test_server_and_client.ml
+++ b/test/test_server_and_client.ml
@@ -4,7 +4,7 @@ open Picos_stdio
 open Picos_sync
 
 let is_ocaml4 = String.starts_with ~prefix:"4." Sys.ocaml_version
-let use_nonblock = Sys.win32 || Random.bool ()
+let use_nonblock = Sys.win32 (*|| Random.bool ()*)
 
 let set_nonblock fd =
   if use_nonblock then
@@ -91,7 +91,9 @@ let main () =
     | exception Unix.Unix_error (EPERM, _, _) when is_opam_ci -> raise Exit
   in
 
-  let server = if Random.bool () then server_looping else server_recursive in
+  let server =
+    if Random.bool () || true then server_looping else server_recursive
+  in
 
   let client id () =
     Printf.printf "  Client %s running\n%!" id;


### PR DESCRIPTION
I noticed the server and client test crashed with a SIGSEGV or SIGBUS (depending on run).  I created a stripped down version of the program

  https://github.com/polytypic/signal-issue

that removes all "unsafe" optimizations and it still crashes on macOS with ARM (tested on M1 and M3).

I recall seeing the server and client test also crash on non macOS machines, but it seems to be more difficult to reproduce.  This is an ettempt to get it to reproduce on OCaml-CI.