### PR TITLE
Support multi-threaded use in `Picos_randos`

### DIFF
--- a/lib/picos_randos/dune
+++ b/lib/picos_randos/dune
@@ -10,4 +10,5 @@
    from
    (picos.select -> select.some.ml)
    (-> select.none.ml))
+  multicore-magic
   picos.htbl))

--- a/lib/picos_randos/picos_randos.mli
+++ b/lib/picos_randos/picos_randos.mli
@@ -1,4 +1,4 @@
-(** Randomized single-threaded effects based {!Picos} compatible scheduler for
+(** Randomized multi-threaded effects based {!Picos} compatible scheduler for
     OCaml 5.
 
     ℹ️ This scheduler implementation is specifically intended for testing
@@ -10,9 +10,29 @@
     bugs in programs implemented in Picos that make invalid scheduling
     assumptions. *)
 
-val run : ?forbid:bool -> (unit -> 'a) -> 'a
+type t
+(** Represents a shared context for randomized runners. *)
+
+val context : unit -> t
+(** [context ()] creates a new context for randomized runners.  The context
+    should be consumed by a call of {{!run} [run ~context ...]}. *)
+
+val runner_on_this_thread : t -> unit
+(** [runner_on_this_thread context] starts a runner on the current thread to run
+    fibers on the context.  The runner returns when {{!run} [run ~context ...]}
+    returns. *)
+
+val run : ?context:t -> ?forbid:bool -> (unit -> 'a) -> 'a
 (** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
     and all of the fibers spawned by [main] have returned.
+
+    The optional [context] argument specifies a context in which to run the
+    [main] thunk.  If unspecified, a new context is automatically created and
+    the scheduler will be single-threaded.  By {{!context} creating a context},
+    spawning concurrent or parallel {{!runner_on_this_thread} runners} on to the
+    context, and then explicitly passing the context to [run ~context ...] one
+    can create a multi-threaded scheduler.  Only a single call of {!run} per
+    context is allowed.
 
     The optional [forbid] argument defaults to [false] and determines whether
     propagation of cancelation is initially allowed. *)

--- a/test/dune
+++ b/test/dune
@@ -6,7 +6,7 @@
   (select
    test_scheduler.ml
    from
-   (picos.fifos picos.randos -> test_scheduler.ocaml5.ml)
+   (picos.fifos picos.randos picos.structured -> test_scheduler.ocaml5.ml)
    (picos.threaded -> test_scheduler.ocaml4.ml))))
 
 (library
@@ -31,7 +31,7 @@
 (test
  (name test_sync)
  (modules test_sync)
- (libraries picos.sync test_scheduler alcotest domain_shims))
+ (libraries picos.structured picos.sync test_scheduler alcotest domain_shims))
 
 ;;
 

--- a/test/test_picos.ml
+++ b/test/test_picos.ml
@@ -19,7 +19,7 @@ let test_fls_basics =
   in
 
   fun () ->
-    Test_scheduler.run @@ fun () ->
+    Test_scheduler.run ~max_domains:2 @@ fun () ->
     let first =
       run_in_fiber @@ fun () ->
       let fiber = Fiber.current () in
@@ -103,7 +103,7 @@ let test_thread_cancelation () =
 
 let test_cancel_after () =
   Alcotest.check_raises "should be canceled" Not_found @@ fun () ->
-  Test_scheduler.run @@ fun () ->
+  Test_scheduler.run ~max_domains:2 @@ fun () ->
   let computation = Computation.create () in
   let main =
     Computation.capture computation @@ fun () ->

--- a/test/test_scheduler.ocaml4.ml
+++ b/test/test_scheduler.ocaml4.ml
@@ -1,2 +1,2 @@
 let () = Random.self_init ()
-let run ?forbid main = Picos_threaded.run ?forbid main
+let run ?max_domains:_ ?forbid main = Picos_threaded.run ?forbid main

--- a/test/test_scheduler.ocaml5.ml
+++ b/test/test_scheduler.ocaml5.ml
@@ -1,5 +1,22 @@
+open Picos_structured.Finally
+
 let use_randos = Random.bool (Random.self_init ())
 
-let run ?forbid main =
-  if use_randos then Picos_randos.run ?forbid main
+let run ?(max_domains = 1) ?forbid main =
+  if use_randos then
+    let context = Picos_randos.context () in
+    let rec spawn n =
+      if n <= 1 then Picos_randos.run ~context ?forbid main
+      else
+        let@ _ =
+          finally Domain.join @@ fun () ->
+          try
+            Domain.spawn @@ fun () -> Picos_randos.runner_on_this_thread context
+          with exn ->
+            Picos_randos.run ~context Fun.id;
+            raise exn
+        in
+        spawn (n - 1)
+    in
+    spawn (Int.min max_domains (Domain.recommended_domain_count ()))
   else Picos_fifos.run ?forbid main

--- a/test/test_schedulers.ml
+++ b/test/test_schedulers.ml
@@ -7,7 +7,7 @@ let test_returns () =
   assert (actual = 42)
 
 let test_current () =
-  Test_scheduler.run @@ fun () ->
+  Test_scheduler.run ~max_domains:2 @@ fun () ->
   let fiber_parent = Fiber.current () in
   let fiber_child = ref fiber_parent in
   let computation = Computation.create () in

--- a/test/test_server_and_client.ml
+++ b/test/test_server_and_client.ml
@@ -128,6 +128,6 @@ let () =
   Printf.printf "Using %sblocking sockets and %s:\n%!"
     (if use_nonblock then "non-" else "")
     (if is_ocaml4 then "threads on OCaml 4" else "fibers on OCaml 5");
-  try Test_scheduler.run main with
+  try Test_scheduler.run ~max_domains:4 main with
   | Exit -> Printf.printf "Server and Client test: SKIPPED\n%!"
   | exn -> Printf.printf "Error: %s\n%!" (Printexc.to_string exn)


### PR DESCRIPTION
This PR adds a low level interface to `Picos_randos` to allow it to use multiple threads and/or domains.