### PR TITLE
Implement `Picos_htbl` using `Atomic_array`

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,7 @@
    (>= 0.2.1))
   ;; For mpsc queue
   (multicore-magic
-   (>= 2.1.0))
+   (>= 2.2.0))
   ;; For picos.lwt
   (lwt
    (>= 5.7.0))

--- a/picos.opam
+++ b/picos.opam
@@ -14,7 +14,7 @@ depends: [
   "thread-local-storage" {>= "0.1"}
   "mtime" {>= "2.0.0"}
   "psq" {>= "0.2.1"}
-  "multicore-magic" {>= "2.1.0"}
+  "multicore-magic" {>= "2.2.0"}
   "lwt" {>= "5.7.0"}
   "multicore-bench" {>= "0.1.3" & with-test}
   "alcotest" {>= "1.7.0" & with-test}


### PR DESCRIPTION
See [PR in multicore-magic](https://github.com/ocaml-multicore/multicore-magic/pull/13).

This seems to improve performance in cases of low contention and potentially degrades performance in cases of high contention, which is natural, because an unboxed atomic array uses less words of memory, which makes false sharing more likely.  The performance of this kind of table is naturally relatively worse in cases of low contention (when e.g. compared to lock based techniques), so it makes sense to implement optimizations that improve relative performance in cases of low contention.

I experimented briefly with scaling the capacity based on the number of domains accessing the table in parallel.  However, the results of that were not conclusive, i.e. it is unclear whether there was a performance improvement.  I think further work could be done to tune this for best performance.

Note that even though only relaxed reads from an atomic array are provided, the table as a whole is still linearizable.  That is simply because the "root" of this hash table is an atomic.  Every operation on a hash table begins with an `Atomic.get`.  This means that all the relaxed atomic reads from the internal array will happen between sequentially consistent atomic operations and cannot be reordered to break linearizability.