### PR TITLE
Avoid cost of `include`

### DIFF
--- a/lib/picos_htbl/atomic.ml
+++ b/lib/picos_htbl/atomic.ml
@@ -1,1 +1,0 @@
-include Multicore_magic.Transparent_atomic

--- a/lib/picos_htbl/picos_htbl.ml
+++ b/lib/picos_htbl/picos_htbl.ml
@@ -12,6 +12,8 @@ let ceil_pow_2_minus_1 n =
        Nativeint.logor n (Nativeint.shift_right_logical n 32)
      else n)
 
+module Atomic = Multicore_magic.Transparent_atomic
+
 type 'k hashed_type = (module Stdlib.Hashtbl.HashedType with type t = 'k)
 
 type ('k, 'v, _) tdt =


### PR DESCRIPTION
The `include` construct at the module level is quite expensive in terms of generated code size.