### PR TITLE
Change `Picos_lwt` to take `module System` as argument

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-windows:
     strategy:
+      fail-fast: false
       matrix:
         ocaml-compiler:
           - ocaml.5.0.0,ocaml-option-mingw

--- a/bench/bench_binaries.ml
+++ b/bench/bench_binaries.ml
@@ -13,6 +13,7 @@ let paths =
     lib "picos_fifos";
     lib "picos_htbl";
     lib "picos_lwt";
+    lib "picos_lwt_unix";
     lib "picos_mpscq";
     lib "picos_randos";
     lib "picos_rc";

--- a/lib/index.mld
+++ b/lib/index.mld
@@ -150,6 +150,7 @@ These are minimalistic, but fully-functioning, schedulers provided as samples.
 {!modules:
   Picos_fifos
   Picos_lwt
+  Picos_lwt_unix
   Picos_randos
   Picos_threaded
 }

--- a/lib/picos_lwt/dune
+++ b/lib/picos_lwt/dune
@@ -5,4 +5,5 @@
   (>= %{ocaml_version} 5.0.0))
  (libraries
   (re_export picos)
-  (re_export lwt)))
+  (re_export lwt)
+  picos.thread))

--- a/lib/picos_lwt_unix/dune
+++ b/lib/picos_lwt_unix/dune
@@ -1,0 +1,11 @@
+(library
+ (name picos_lwt_unix)
+ (public_name picos.lwt_unix)
+ (optional)
+ (libraries
+  (re_export picos.lwt)
+  (re_export lwt)
+  (re_export lwt.unix)
+  picos.mpscq
+  picos.thread
+  unix))

--- a/lib/picos_lwt_unix/picos_lwt_unix.ml
+++ b/lib/picos_lwt_unix/picos_lwt_unix.ml
@@ -1,0 +1,94 @@
+open Lwt.Infix
+
+let[@inline never] not_main_thread () =
+  invalid_arg "not called from the main thread"
+
+let ready = Picos_mpscq.create ()
+
+type pipes = {
+  mutable count : int;
+  mutable inn : Lwt_unix.file_descr;
+  mutable out : Unix.file_descr;
+  mutable close_promise : int Lwt.t;
+  mutable close_resolver : int Lwt.u;
+}
+
+let pipes =
+  let close_promise, close_resolver = Lwt.wait () in
+  {
+    count = 0;
+    inn = Lwt_unix.stdin;
+    out = Unix.stdout;
+    close_promise;
+    close_resolver;
+  }
+
+let byte = Bytes.create 1
+
+let rec forever () =
+  match Picos_mpscq.pop_exn ready with
+  | resolver ->
+      Lwt.wakeup resolver ();
+      forever ()
+  | exception Picos_mpscq.Empty ->
+      let inn = pipes.inn in
+      if inn == Lwt_unix.stdin then Lwt.return_unit
+      else
+        Lwt.pick [ pipes.close_promise; Lwt_unix.read inn byte 0 1 ]
+        >>= forever_check
+
+and forever_check n = if n < 0 then Lwt.return_unit else forever ()
+
+module System = struct
+  let sleep = Lwt_unix.sleep
+
+  type trigger = unit Lwt.t * unit Lwt.u
+
+  let trigger = Lwt.wait
+
+  let signal (_, resolver) =
+    if Picos_thread.is_main_thread () then Lwt.wakeup resolver ()
+    else begin
+      Picos_mpscq.push ready resolver;
+      assert (1 = Unix.write pipes.out byte 0 1)
+    end
+
+  let await (promise, _) = promise
+end
+
+let system = (module System : Picos_lwt.System)
+
+let pipes_incr () =
+  let count = pipes.count + 1 in
+  if count = 1 then begin
+    let promise, resolver = Lwt.wait () in
+    pipes.close_promise <- promise;
+    pipes.close_resolver <- resolver;
+    let inn, out = Lwt_unix.pipe_in ~cloexec:true () in
+    pipes.inn <- inn;
+    pipes.out <- out;
+    pipes.count <- count;
+    Lwt.async forever
+  end
+  else pipes.count <- count
+
+let pipes_decr _ =
+  let count = pipes.count - 1 in
+  if count = 0 then begin
+    Lwt.wakeup pipes.close_resolver (-1);
+    Unix.close pipes.out;
+    pipes.out <- Unix.stdout;
+    Lwt.async (fun () -> Lwt_unix.close pipes.inn);
+    pipes.inn <- Lwt_unix.stdin;
+    pipes.count <- count
+  end
+  else pipes.count <- count
+
+let run ?forbid main =
+  if not (Picos_thread.is_main_thread ()) then not_main_thread ();
+  pipes_incr ();
+  let promise = Picos_lwt.run ?forbid system main in
+  Lwt.on_any promise pipes_decr pipes_decr;
+  promise
+
+let () = Lwt_main.run (Lwt_unix.sleep 0.0)

--- a/lib/picos_lwt_unix/picos_lwt_unix.mli
+++ b/lib/picos_lwt_unix/picos_lwt_unix.mli
@@ -1,0 +1,9 @@
+(** Direct style {!Picos} compatible interface to {!Lwt} with {!Lwt_unix} for
+    OCaml 5. *)
+
+val run : ?forbid:bool -> (unit -> 'a) -> 'a Lwt.t
+(** [run main] runs the [main] program implemented in {!Picos} as a promise with
+    {!Lwt} as the scheduler with {!Lwt_unix} based {{!Picos_lwt.System}
+    system}.
+
+    ⚠️ This may only be called on the main thread on which {!Lwt} runs. *)

--- a/lib/picos_randos/picos_randos.ml
+++ b/lib/picos_randos/picos_randos.ml
@@ -183,7 +183,9 @@ let context () =
   in
   t
 
-let runner_on_this_thread = next
+let runner_on_this_thread t =
+  Select.check_configured ();
+  next t
 
 let rec await t computation =
   if !(t.num_waiters_non_zero) then begin
@@ -199,7 +201,13 @@ let rec await t computation =
   end
 
 let run ?context:t_opt ?(forbid = false) main =
-  let t = match t_opt with Some t -> t | None -> context () in
+  let t =
+    match t_opt with
+    | Some t ->
+        Select.check_configured ();
+        t
+    | None -> context ()
+  in
   Mutex.lock t.mutex;
   if t.run then begin
     Mutex.unlock t.mutex;

--- a/lib/picos_select/picos_select.mli
+++ b/lib/picos_select/picos_select.mli
@@ -112,7 +112,8 @@ val handle_signal : int -> unit
 val check_configured : unit -> unit
 (** [check_configured ()] checks whether this module has already been
     {{!configure} configured} or not and, if not, calls {!configure} with
-    default arguments.
+    default arguments.  In either case, calling [check_configured ()] will
+    (re)configure signal handling for the current thread.
 
     ℹ️ The intended use case for [check_configure ()] is at the point of
     entry of schedulers and other facilities that use this module. *)

--- a/lib/picos_thread/picos_thread.posix.ml
+++ b/lib/picos_thread/picos_thread.posix.ml
@@ -1,4 +1,4 @@
-let main_thread = Thread.id (Thread.self ())
-let is_main_thread () = Thread.id (Thread.self ()) = main_thread
+let main_thread = Thread.self ()
+let is_main_thread () = Thread.self () == main_thread
 
 module TLS = Thread_local_storage

--- a/test/dune
+++ b/test/dune
@@ -3,11 +3,18 @@
  (modules test_scheduler)
  (libraries
   (re_export picos)
+  picos.select
   (select
    test_scheduler.ml
    from
-   (picos.fifos picos.randos picos.structured -> test_scheduler.ocaml5.ml)
-   (picos.threaded -> test_scheduler.ocaml4.ml))))
+   (picos.fifos
+    picos.randos
+    picos.lwt_unix
+    picos.structured
+    picos.thread
+    ->
+    test_scheduler.ocaml5.ml)
+   (picos.threaded lwt.unix -> test_scheduler.ocaml4.ml))))
 
 (library
  (name test_util)
@@ -40,7 +47,7 @@
  (modules test_lwt_unix)
  (build_if
   (>= %{ocaml_version} 5.0.0))
- (libraries picos.lwt lwt.unix alcotest))
+ (libraries picos.lwt_unix alcotest))
 
 ;;
 

--- a/test/test_lwt_unix.ml
+++ b/test/test_lwt_unix.ml
@@ -1,8 +1,7 @@
 open Picos
 
 let basics () =
-  Lwt_main.run
-  @@ Picos_lwt.run ~sleep:Lwt_unix.sleep
+  Lwt_main.run @@ Picos_lwt_unix.run
   @@ fun () ->
   let computation = Computation.create () in
   let child =

--- a/test/test_scheduler.ocaml4.ml
+++ b/test/test_scheduler.ocaml4.ml
@@ -1,2 +1,19 @@
+let () = Printexc.record_backtrace true
 let () = Random.self_init ()
-let run ?max_domains:_ ?forbid main = Picos_threaded.run ?forbid main
+
+let () =
+  Picos_select.check_configured ();
+
+  let[@alert "-handler"] rec propagate () =
+    let computation =
+      Picos.Computation.with_action () () @@ fun _ _ _ ->
+      (* Note that [handle_signal] is documented to be "thread-safe". *)
+      Lwt_unix.handle_signal Sys.sigchld;
+      propagate ()
+    in
+    Picos_select.return_on_sigchld computation ()
+  in
+  propagate ()
+
+let run ?max_domains:_ ?allow_lwt:_ ?forbid main =
+  Picos_threaded.run ?forbid main

--- a/test/test_scheduler.ocaml5.ml
+++ b/test/test_scheduler.ocaml5.ml
@@ -1,22 +1,46 @@
+let () = Printexc.record_backtrace true
+let () = Random.self_init ()
+
 open Picos_structured.Finally
 
-let use_randos = Random.bool (Random.self_init ())
+let () =
+  Picos_select.check_configured ();
 
-let run ?(max_domains = 1) ?forbid main =
-  if use_randos then
-    let context = Picos_randos.context () in
-    let rec spawn n =
-      if n <= 1 then Picos_randos.run ~context ?forbid main
-      else
-        let@ _ =
-          finally Domain.join @@ fun () ->
-          try
-            Domain.spawn @@ fun () -> Picos_randos.runner_on_this_thread context
-          with exn ->
-            Picos_randos.run ~context Fun.id;
-            raise exn
-        in
-        spawn (n - 1)
+  let[@alert "-handler"] rec propagate () =
+    let computation =
+      Picos.Computation.with_action () () @@ fun _ _ _ ->
+      (* Note that [handle_signal] is documented to be "thread-safe". *)
+      Lwt_unix.handle_signal Sys.sigchld;
+      propagate ()
     in
-    spawn (Int.min max_domains (Domain.recommended_domain_count ()))
-  else Picos_fifos.run ?forbid main
+    Picos_select.return_on_sigchld computation ()
+  in
+  propagate ()
+
+let rec run ?(max_domains = 1) ?(allow_lwt = true) ?forbid main =
+  let scheduler =
+    match Random.int 3 with 0 -> `Fifos | 1 -> `Randos | _ -> `Lwt
+  in
+  match scheduler with
+  | `Lwt ->
+      if Picos_thread.is_main_thread () && allow_lwt then
+        Lwt_main.run (Picos_lwt_unix.run ?forbid main)
+      else run ~max_domains ~allow_lwt ?forbid main
+  | `Randos ->
+      let context = Picos_randos.context () in
+      let rec spawn n =
+        if n <= 1 then Picos_randos.run ~context ?forbid main
+        else
+          let@ _ =
+            finally Domain.join @@ fun () ->
+            try
+              Domain.spawn @@ fun () ->
+              Picos_randos.runner_on_this_thread context
+            with exn ->
+              Picos_randos.run ~context Fun.id;
+              raise exn
+          in
+          spawn (n - 1)
+      in
+      spawn (Int.min max_domains (Domain.recommended_domain_count ()))
+  | `Fifos -> Picos_fifos.run ?forbid main

--- a/test/test_stdio_with_lwt.ml
+++ b/test/test_stdio_with_lwt.ml
@@ -1,22 +1,10 @@
-open Picos
 open Picos_stdio
-
-let () =
-  let[@alert "-handler"] rec propagate () =
-    let computation =
-      Computation.with_action () () @@ fun _ _ _ ->
-      Lwt_unix.handle_signal Sys.sigchld;
-      propagate ()
-    in
-    Picos_select.return_on_sigchld computation ()
-  in
-  propagate ()
 
 let test_system_unix () =
   let sleep = Lwt_unix.system "sleep 2" in
   Lwt_main.run @@ Lwt.bind sleep
   @@ fun _status ->
-  Test_scheduler.run @@ fun () ->
+  Test_scheduler.run ~allow_lwt:false @@ fun () ->
   assert (Unix.system "exit 101" = Unix.WEXITED 101);
   assert (Unix.system "echo Hello world!" = Unix.WEXITED 0);
   assert (Unix.system "this-is-not-supposed-to-exist" = Unix.WEXITED 127);


### PR DESCRIPTION
The `System` module is then used to give both a `sleep` function and a kind of trigger mechanism.  The trigger mechanism is needed to be able to safely wake up Lwt in a multi threaded and/or multi domain program.  I think it could actually be a good idea to add more multicore OCaml to Lwt to allow some way to safely interact with Lwt from any systhread on any domain.

This PR also tweaks the way the `Test_scheduler` does things and sets up signal handling in a way that it can work with both `Picos_stdio.Unix` and `Lwt_unix`.  However, the approach done to setup signal handling is a bit of hack, IMHO.  It does seem to work, but this should probably be revisited at some point.  Ideally there would be some library that allows other libraries to setup signal handlers more cooperatively.  The current unix/stdlib approach to setting up signal handling is non-composable and non-cooperative.