### PR TITLE
Add `Event` abstraction to `Picos_sync`

### DIFF
--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -410,7 +410,7 @@ module Computation : sig
       {{!is_running} running to completed}.
 
       A hopefully enlightening analogy is that a computation is a kind of
-      single-shot atomic event.
+      single-shot atomic {{!Picos_sync.Event} event}.
 
       Another hopefully helpful analogy is that a computation is basically like
       a {{!Picos_structured.Promise} cancelable promise} and a basic
@@ -695,14 +695,14 @@ module Computation : sig
       computations able to support a variety of purposes such as the
       implementation of {{!Picos_structured} structured concurrency}.
 
-      The computation concept can be seen as a kind of single-shot atomic event
-      that is a generalization of both a cancelation context or token and of a
-      {{!Picos_structured.Promise} promise}.  Unlike a typical promise
-      mechanism, a computation can be canceled.  Unlike a typical cancelation
-      mechanism, a computation can and should also be completed in case it is
-      not canceled.  This promotes proper scoping of computations and resource
-      cleanup at completion, which is how the design evolved from a more
-      traditional cancelation context design.
+      The computation concept can be seen as a kind of single-shot atomic
+      {{!Picos_sync.Event} event} that is a generalization of both a cancelation
+      context or token and of a {{!Picos_structured.Promise} promise}.  Unlike a
+      typical promise mechanism, a computation can be canceled.  Unlike a
+      typical cancelation mechanism, a computation can and should also be
+      completed in case it is not canceled.  This promotes proper scoping of
+      computations and resource cleanup at completion, which is how the design
+      evolved from a more traditional cancelation context design.
 
       Every fiber is {{!Fiber.get_computation} associated with a computation}.
       Being able to return a value through the computation means that no

--- a/lib/picos_select/dune
+++ b/lib/picos_select/dune
@@ -6,6 +6,7 @@
   (re_export picos)
   (re_export picos.exn_bt)
   (re_export picos.fd)
+  (re_export picos.sync)
   (re_export unix)
   picos.domain
   picos.thread
@@ -27,5 +28,6 @@
   picos.select
   picos.stdio
   picos.structured
+  picos.sync
   unix)
  (files picos_select.mli))

--- a/lib/picos_sync/event.ml
+++ b/lib/picos_sync/event.ml
@@ -1,0 +1,73 @@
+open Picos
+
+type 'a request = {
+  request : 'r. (unit -> 'r) Computation.t -> ('a -> 'r) -> unit;
+}
+[@@unboxed]
+
+type 'a t =
+  | Request : 'a request -> 'a t
+  | Choose : 'a t list -> 'a t
+  | Wrap : { event : 'b t; fn : 'b -> 'a } -> 'a t
+
+type ('a, 'r) id = Yes : ('a, 'a) id | No : ('a, 'r) id
+
+let rec request_1_as :
+    type a r. (_ -> r) Computation.t -> (a -> r) -> (a, r) id -> a t -> _ =
+ fun computation to_result id -> function
+  | Request { request } -> request computation to_result
+  | Choose ts -> request_n_as computation to_result id ts
+  | Wrap { event; fn } ->
+      let to_result =
+        match id with No -> fun x -> to_result (fn x) | Yes -> fn
+      in
+      request_1_as computation to_result No event
+
+and request_n_as :
+    type a r. (_ -> r) Computation.t -> (a -> r) -> (a, r) id -> a t list -> _ =
+ fun computation to_result id -> function
+  | [] -> ()
+  | t :: ts ->
+      request_1_as computation to_result id t;
+      request_n_as computation to_result id ts
+
+type ('a, _) tycon = Id : ('a, 'a t) tycon | List : ('a, 'a t list) tycon
+
+let sync_as : type a n. n -> (a, n) tycon -> a =
+ fun t n ->
+  let computation = Computation.create ~mode:`LIFO () in
+  match
+    match n with
+    | Id -> request_1_as computation Fun.id Yes t
+    | List -> request_n_as computation Fun.id Yes t
+  with
+  | () ->
+      if Computation.is_running computation then begin
+        let t = Trigger.create () in
+        if Computation.try_attach computation t then
+          match Trigger.await t with
+          | None -> ()
+          | Some exn_bt ->
+              if Computation.try_cancel computation exn_bt then
+                Exn_bt.raise exn_bt
+      end;
+      Computation.await computation ()
+  | exception exn ->
+      let exn_bt = Exn_bt.get exn in
+      Computation.cancel computation exn_bt;
+      Exn_bt.raise exn_bt
+
+let guard create_event =
+  let request computation to_result =
+    request_1_as computation to_result No (create_event ())
+  in
+  Request { request }
+
+type 'a event = 'a t
+
+let[@inline] from_request p = Request p
+let[@inline] choose ts = Choose ts
+let[@inline] wrap event fn = Wrap { event; fn }
+let[@inline] map fn event = Wrap { event; fn }
+let[@inline] sync t = sync_as t Id
+let[@inline] select ts = sync_as ts List

--- a/lib/picos_sync/picos_sync.ml
+++ b/lib/picos_sync/picos_sync.ml
@@ -1,3 +1,4 @@
 module Mutex = Mutex
 module Condition = Condition
 module Lazy = Lazy
+module Event = Event

--- a/lib/picos_sync/picos_sync.mli
+++ b/lib/picos_sync/picos_sync.mli
@@ -158,6 +158,99 @@ module Lazy : sig
       ]} *)
 end
 
+module Event : sig
+  (** An implementation of first-class synchronous communication for {!Picos}.
+
+      Events describe a thing that might happen in the future, or a concurrent
+      offer or request that might be accepted or succeed, but is cancelable if
+      some other event happens first.
+
+      ℹ️ This module intentionally mimics the
+      {{:https://ocaml.org/manual/5.2/api/Event.html} [Event]} module provided
+      by the OCaml POSIX threads library. *)
+
+  type !'a t
+  (** An event returning a value of type ['a]. *)
+
+  type 'a event = 'a t
+  (** An alias for the {!Event.t} type to match the
+      {{:https://ocaml.org/manual/5.2/api/Event.html} [Event]} module
+      signature. *)
+
+  (** {2 Composing events} *)
+
+  val choose : 'a t list -> 'a t
+  (** [choose events] return an event that offers all of the given events and
+      then commits to at most one of them. *)
+
+  val wrap : 'b t -> ('b -> 'a) -> 'a t
+  (** [wrap event fn] returns an event that acts as the given [event] and then
+      applies the given function to the value in case the event is committed
+      to. *)
+
+  val map : ('b -> 'a) -> 'b t -> 'a t
+  (** [map fn event] is equivalent to {{!wrap} [wrap event fn]}. *)
+
+  val guard : (unit -> 'a t) -> 'a t
+  (** [guard thunk] returns an event that, when {{!sync} synchronized}, calls
+      the [thunk], and then behaves like the resulting event.
+
+      ⚠️ Raising an exception from a [guard thunk] will result in raising that
+      exception out of the {!sync}.  This may result in dropping the result of
+      an event that committed just after the exception was raised.  This means
+      that you should treat an unexpected exception raised from {!sync} as a
+      fatal error. *)
+
+  (** {2 Consuming events} *)
+
+  val sync : 'a t -> 'a
+  (** [sync event] synchronizes on the given event.
+
+      Synchronizing on an event executes in three phases:
+
+      {ol
+        {- In the first phase offers or requests are made to communicate.}
+        {- One of the offers or requests is committed to and all the other
+           offers and requests are canceled.}
+        {- A final result is computed from the value produced by the event.}}
+
+      ⚠️ [sync event] does not wait for the canceled concurrent requests to
+      terminate.  This means that you should arrange for guaranteed cleanup
+      through other means such as the use of {{!Picos_structured} structured
+      concurrency}. *)
+
+  val select : 'a t list -> 'a
+  (** [select events] is equivalent to {{!sync} [sync (choose events)]}. *)
+
+  (** {2 Primitive events}
+
+      ℹ️ The {{!Picos.Computation} [Computation]} concept of {!Picos} can be seen
+      as a basic single-shot atomic event.  This module builds on that concept
+      to provide a composable API to concurrent services exposed through
+      computations. *)
+
+  open Picos
+
+  type 'a request = {
+    request : 'r. (unit -> 'r) Computation.t -> ('a -> 'r) -> unit;
+  }
+  [@@unboxed]
+  (** Represents a function that request a concurrent service to update a
+      {{!Picos.Computation} computation}.
+
+      ⚠️ Raising an exception from a [request] function will result in raising
+      that exception out of the {!sync}.  This may result in dropping the result
+      of an event that committed just after the exception was raised.  This
+      means that you should treat an unexpected exception raised from {!sync} as
+      a fatal error.  In addition, you should arrange for concurrent services to
+      report unexpected errors independently of the computation being passed to
+      the service. *)
+
+  val from_request : 'a request -> 'a t
+  (** [from_request { request }] creates an {{!Event} event} from the request
+      function. *)
+end
+
 (** {1 Examples}
 
     First we open some modules for convenience:


### PR DESCRIPTION
This PR adds an `Event` module providing a subset of the functionality of the [`Event`](https://ocaml.org/manual/5.2/api/Event.html) module provided by the POSIX threads library that is distributed with OCaml.

The basic idea for this arise out of discussions with @c-cube.  We realized that the `Computation` concept provided by the Picos core interface is quite close to providing everything necessary to implement Concurrent ML style events.

The main feature missing to provide full Concurrent ML style events would be the ability to atomically complete two computations.  It is possible to implement such an operation (I know several techniques that would work), but that is left for future work.  Another feature missing is `wrap_abort` and/or `with_nack`.  It should also be possible to implement such a feature, but `Computation` handles cancelation slightly differently (i.e. typically, when a "primitive" request is created, one also attaches a cancelation trigger to the computation).

The ability to choose from multiple events and map over the result can already be quite useful.  It is not clear whether it is worth the effort to provide full Concurrent ML style events and it is left for future work.  If you are reading this, because you are looking for the missing functionality, feel free to create an issue and I'll probably create a quick prototype.