### PR TITLE
Add a many-to-many, poisonable stream

### DIFF
--- a/bench/bench_stream.ml
+++ b/bench/bench_stream.ml
@@ -1,0 +1,77 @@
+open Multicore_bench
+module Stream = Picos_sync.Stream
+
+let run_one_domain ~budgetf ?(n_msgs = 50 * Util.iter_factor) () =
+  let t = Stream.create ~padded:true () in
+
+  let cursor = ref (Stream.tap t) in
+
+  let op push =
+    if push then Stream.push t 101
+    else
+      match Stream.peek_opt !cursor with
+      | None -> ()
+      | Some (_, c) -> cursor := c
+  in
+
+  let init _ =
+    assert (Stream.peek_opt !cursor == None);
+    Util.generate_push_and_pop_sequence n_msgs
+  in
+  let work _ bits = Util.Bits.iter op bits in
+
+  Times.record ~budgetf ~n_domains:1 ~init ~work ()
+  |> Times.to_thruput_metrics ~n:n_msgs ~singular:"message" ~config:"one domain"
+
+let run_one ~budgetf ~n_pusher () =
+  let n_readers = 1 in
+  let n_domains = n_pusher + n_readers in
+
+  let n_msgs = 200 / n_readers * Util.iter_factor in
+
+  let t = Stream.create ~padded:true () in
+
+  let n_msgs_to_add = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+
+  let init _ =
+    Atomic.set n_msgs_to_add n_msgs;
+    Stream.tap t
+  in
+  let wrap _ _ = Scheduler.run in
+  let work i c =
+    if i < n_pusher then
+      let rec work () =
+        let n = Util.alloc n_msgs_to_add in
+        if 0 < n then begin
+          for i = 1 to n do
+            Stream.push t i
+          done;
+          work ()
+        end
+      in
+      work ()
+    else
+      let rec loop n c =
+        if 0 < n then
+          match Stream.peek_opt c with
+          | None ->
+              Backoff.once Backoff.default |> ignore;
+              loop n c
+          | Some (_, c) -> loop (n - 1) c
+      in
+      loop n_msgs c
+  in
+
+  let config =
+    let format role n =
+      Printf.sprintf "%d %s%s" n role (if n = 1 then "" else "s")
+    in
+    Printf.sprintf "%s, 1 nb reader" (format "nb pusher" n_pusher)
+  in
+  Times.record ~budgetf ~n_domains ~init ~wrap ~work ()
+  |> Times.to_thruput_metrics ~n:n_msgs ~singular:"message" ~config
+
+let run_suite ~budgetf =
+  run_one_domain ~budgetf ()
+  @ ([ 1; 2; 4 ]
+    |> List.concat_map @@ fun n_pusher -> run_one ~budgetf ~n_pusher ())

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -15,6 +15,7 @@ let benchmarks =
     ("Picos_mpscq", Bench_mpscq.run_suite);
     ("Picos_htbl", Bench_htbl.run_suite);
     ("Picos_stdio", Bench_stdio.run_suite);
+    ("Picos_sync Stream", Bench_stream.run_suite);
     ("Fib", Bench_fib.run_suite);
     ("Picos binaries", Bench_binaries.run_suite);
     ("Bounded_q with Picos_sync", Bench_bounded_q.run_suite);

--- a/lib/picos_sync/picos_sync.ml
+++ b/lib/picos_sync/picos_sync.ml
@@ -4,3 +4,4 @@ module Lazy = Lazy
 module Event = Event
 module Latch = Latch
 module Ivar = Ivar
+module Stream = Stream

--- a/lib/picos_sync/stream.ml
+++ b/lib/picos_sync/stream.ml
@@ -1,0 +1,44 @@
+open Picos
+
+type 'a cursor = Cons of ('a * 'a cursor) Computation.t [@@unboxed]
+type 'a t = 'a cursor Atomic.t
+
+let create ?padded () =
+  Multicore_magic.copy_as ?padded
+    (Atomic.make (Cons (Computation.create ~mode:`LIFO ())))
+
+let[@inline] advance t tail curr =
+  if Atomic.get t == Cons tail then
+    Atomic.compare_and_set t (Cons tail) curr |> ignore
+
+let[@inline] help t tail =
+  let _, curr = Computation.await tail in
+  advance t tail curr
+
+let rec push t ((_, curr) as next) backoff =
+  let (Cons tail) = Atomic.get t in
+  if Computation.try_return tail next then advance t tail curr
+  else
+    let backoff = Backoff.once backoff in
+    help t tail;
+    push t next backoff
+
+let push t value =
+  let next = (value, Cons (Computation.create ~mode:`LIFO ())) in
+  push t next Backoff.default
+
+let rec poison t exn_bt backoff =
+  let (Cons tail) = Atomic.get t in
+  if not (Computation.try_cancel tail exn_bt) then begin
+    let backoff = Backoff.once backoff in
+    help t tail;
+    poison t exn_bt backoff
+  end
+
+let peek_opt (Cons at) =
+  if Computation.is_running at then None else Some (Computation.await at)
+
+let poison t exn_bt = poison t exn_bt Backoff.default
+let tap = Atomic.get
+let read (Cons at) = Computation.await at
+let read_evt (Cons at) = Event.from_computation at


### PR DESCRIPTION
This PR adds a many-to-many, poisonable (i.e. closable) stream to the `Picos_sync`.  This is inspired by the [`Multicast` channel](http://cml.cs.uchicago.edu/pages/multicast.html) provided by Concurrent ML and can be useful for a variety of purposes.