### PR TITLE
Use multicore-bench with suite order randomization

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-ocaml-5.2
-RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 WORKDIR bench-dir
+RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 RUN sudo chown opam .
 COPY *.opam ./
 RUN opam remote add origin https://github.com/ocaml/opam-repository.git && \

--- a/dune-project
+++ b/dune-project
@@ -43,7 +43,7 @@
   ;; Test dependencies
   (multicore-bench
    (and
-    (>= 0.1.3)
+    (>= 0.1.4)
     :with-test))
   (alcotest
    (and

--- a/picos.opam
+++ b/picos.opam
@@ -16,7 +16,7 @@ depends: [
   "psq" {>= "0.2.1"}
   "multicore-magic" {>= "2.2.0"}
   "lwt" {>= "5.7.0"}
-  "multicore-bench" {>= "0.1.3" & with-test}
+  "multicore-bench" {>= "0.1.4" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "qcheck-core" {>= "0.21.2" & with-test}
   "qcheck-stm" {>= "0.3" & with-test}


### PR DESCRIPTION
This exposes variation due to effects that individual benchmarks have on the runtime state.
