### PR TITLE
Add `Stdlib` style `Semaphore` module to `Picos_sync`

### DIFF
--- a/bench/bench_semaphore.ml
+++ b/bench/bench_semaphore.ml
@@ -1,0 +1,66 @@
+open Multicore_bench
+open Picos
+open Picos_sync
+open Picos_structured
+
+let is_ocaml4 = String.starts_with ~prefix:"4." Sys.ocaml_version
+
+(** This will keep a domain running. *)
+let yielder computation =
+  let main _ =
+    try
+      while true do
+        Fiber.yield ()
+      done
+    with Exit -> ()
+  in
+  Fiber.spawn (Fiber.create ~forbid:false computation) main
+
+let n_workers = 4
+
+let run_one ~budgetf ~use_domains ~n_resources () =
+  let semaphore = Semaphore.Counting.make ~padded:true n_resources in
+
+  let n_domains = if use_domains then n_workers else 1 in
+  let n_ops =
+    (if use_domains || is_ocaml4 then 10 else 100) * Util.iter_factor
+  in
+
+  let run_worker () =
+    let computation = Computation.create () in
+    if not is_ocaml4 then yielder computation;
+    for _ = 1 to n_ops do
+      Semaphore.Counting.acquire semaphore;
+      Fiber.yield ();
+      Semaphore.Counting.release semaphore
+    done;
+    Computation.cancel computation (Exn_bt.get_callstack 0 Exit)
+  in
+
+  let init _ = () in
+  let wrap _ () = Scheduler.run in
+  let work _ () =
+    if use_domains then run_worker ()
+    else
+      Bundle.join_after @@ fun bundle ->
+      for _ = 1 to n_workers do
+        Bundle.fork bundle run_worker
+      done
+  in
+  let config =
+    Printf.sprintf "%d %s%s, %d resource%s" n_workers
+      (if use_domains then "domain" else "fiber")
+      (if n_workers = 1 then "" else "s")
+      n_resources
+      (if n_resources = 1 then "" else "s")
+  in
+  Times.record ~budgetf ~n_domains ~init ~wrap ~work ()
+  |> Times.to_thruput_metrics ~n:(n_ops * n_workers) ~singular:"acquired yield"
+       ~config
+
+let run_suite ~budgetf =
+  Util.cross [ false; true ] [ 1; 2; 3; 4 ]
+  |> List.concat_map @@ fun (use_domains, n_resources) ->
+     if use_domains && Picos_domain.recommended_domain_count () < n_workers then
+       []
+     else run_one ~budgetf ~use_domains ~n_resources ()

--- a/bench/main.ml
+++ b/bench/main.ml
@@ -8,6 +8,7 @@ let benchmarks =
     ("Picos TLS", Bench_tls.run_suite);
     ("Picos DLS", Bench_dls.run_suite);
     ("Picos Mutex", Bench_mutex.run_suite);
+    ("Picos Semaphore", Bench_semaphore.run_suite);
     ("Picos Spawn", Bench_spawn.run_suite);
     ("Picos Yield", Bench_yield.run_suite);
     ("Picos Cancel_after with Picos_select", Bench_cancel_after.run_suite);

--- a/lib/picos_structured/picos_structured.mli
+++ b/lib/picos_structured/picos_structured.mli
@@ -394,6 +394,20 @@ end
           end;
 
           Flock.fork begin fun () ->
+            let sem =
+              Semaphore.Binary.make false
+            in
+            Semaphore.Binary.acquire sem
+          end;
+
+          Flock.fork begin fun () ->
+            let sem =
+              Semaphore.Counting.make 0
+            in
+            Semaphore.Counting.acquire sem
+          end;
+
+          Flock.fork begin fun () ->
             Event.sync (Event.choose [])
           end;
 
@@ -441,10 +455,11 @@ end
         end
     ]}
 
-    First of all, note that above the {{!Picos_sync.Mutex} [Mutex]} and
-    {{!Picos_sync.Condition} [Condition]} modules come from the {!Picos_sync}
-    library and the {{!Picos_stdio.Unix} [Unix]} module comes from the
-    {!Picos_stdio} library.  They do not come from the standard OCaml libraries.
+    First of all, note that above the {{!Picos_sync.Mutex} [Mutex]},
+    {{!Picos_sync.Condition} [Condition]}, and {{!Picos_sync.Semaphore}
+    [Semaphore]} modules come from the {!Picos_sync} library and the
+    {{!Picos_stdio.Unix} [Unix]} module comes from the {!Picos_stdio} library.
+    They do not come from the standard OCaml libraries.
 
     The above program creates a {{!Flock} flock} of fibers and {{!Flock.fork}
     forks} several fibers to the flock that all block in various ways.  In
@@ -454,6 +469,9 @@ end
     - {!Promise.await} never returns as the promise won't be completed,
     - {{!Picos_sync.Condition.wait} [Condition.wait]} never returns, because the
       condition is never signaled,
+    - {{!Picos_sync.Semaphore.Binary.acquire} [Semaphore.Binary.acquire]} and
+      {{!Picos_sync.Semaphore.Counting.acquire} [Semaphore.Counting.acquire]}
+      never return, because the counts of the semaphores never change from [0],
     - {{!Picos_sync.Event.sync} [Event.sync]} never returns, because the event
       can never be committed to,
     - {{!Picos_sync.Latch.await} [Latch.await]} never returns, because the count

--- a/lib/picos_sync/condition.ml
+++ b/lib/picos_sync/condition.ml
@@ -1,87 +1,49 @@
 open Picos
 
-type state = Empty | Queue of { head : Trigger.t list; tail : Trigger.t list }
-type t = state Atomic.t
+type t = Trigger.t Q.t Atomic.t
 
-let create ?padded () = Multicore_magic.copy_as ?padded @@ Atomic.make Empty
+let create ?padded () =
+  Multicore_magic.copy_as ?padded @@ Atomic.make (Q.T Zero)
 
-let broadcast t =
-  if Atomic.get t != Empty then
-    match Atomic.exchange t Empty with
-    | Empty -> ()
-    | Queue r ->
-        List.iter Trigger.signal r.head;
-        List.iter Trigger.signal (List.rev r.tail)
+let broadcast (t : t) =
+  if Atomic.get t != T Zero then
+    match Atomic.exchange t (T Zero) with
+    | T Zero -> ()
+    | T (One _ as q) -> Q.iter q Trigger.signal
 
 (* We try to avoid starvation of signal by making it so that when, at the start
    of signal or wait, the head is empty, the tail is reversed into the head.
    This way both signal and wait attempt O(1) and O(n) operations at the same
    time. *)
 
-let rec signal t backoff =
+let rec signal (t : t) backoff =
   match Atomic.get t with
-  | Empty -> ()
-  | Queue r as before -> begin
-      match r.head with
-      | trigger :: head ->
-          signal_cas t backoff before
-            (if head == [] && r.tail == [] then Empty else Queue { r with head })
-            trigger
-      | [] -> begin
-          match List.rev r.tail with
-          | trigger :: head ->
-              signal_cas t backoff before
-                (if head == [] then Empty else Queue { head; tail = [] })
-                trigger
-          | [] -> failwith "impossible"
-        end
-    end
+  | T Zero -> ()
+  | T (One _ as q) as before ->
+      let after = Q.tail q in
+      if Atomic.compare_and_set t before after then
+        let trigger = Q.head q in
+        Trigger.signal trigger
+      else signal t (Backoff.once backoff)
 
-and signal_cas t backoff before after trigger =
-  if Atomic.compare_and_set t before after then Trigger.signal trigger
-  else signal t (Backoff.once backoff)
-
-let signal t = signal t Backoff.default
-
-let rec cleanup backoff trigger t =
+let rec cleanup backoff trigger (t : t) =
   (* We have been canceled.  If we can't drop our trigger from the variable, we
      signal the next trigger in queue to make sure each signal wakes up at least
      one non-canceled waiter if possible. *)
   match Atomic.get t with
-  | Empty -> ()
-  | Queue r as before -> begin
-      if r.head != [] then
-        match List_ext.drop_first_or_not_found trigger r.head with
-        | head ->
-            cleanup_cas backoff trigger t before
-              (if head == [] && r.tail == [] then Empty
-               else Queue { r with head })
-        | exception Not_found -> begin
-            match List_ext.drop_first_or_not_found trigger r.tail with
-            | tail ->
-                cleanup_cas backoff trigger t before (Queue { r with tail })
-            | exception Not_found -> signal t
-          end
-      else
-        match List_ext.drop_first_or_not_found trigger r.tail with
-        | tail ->
-            cleanup_cas backoff trigger t before
-              (if tail == [] then Empty else Queue { head = []; tail })
-        | exception Not_found -> signal t
-    end
+  | T Zero -> ()
+  | T (One _ as q) as before ->
+      let after = Q.remove q trigger in
+      if before == after then signal t Backoff.default
+      else if not (Atomic.compare_and_set t before after) then
+        cleanup (Backoff.once backoff) trigger t
 
-and cleanup_cas backoff trigger t before after =
-  if not (Atomic.compare_and_set t before after) then
-    cleanup (Backoff.once backoff) trigger t
-
-let rec wait t mutex trigger fiber backoff =
+let rec wait (t : t) mutex trigger fiber backoff =
   let before = Atomic.get t in
   let after =
     match before with
-    | Empty -> Queue { head = [ trigger ]; tail = [] }
-    | Queue r ->
-        if r.head != [] then Queue { r with tail = trigger :: r.tail }
-        else Queue { head = List.rev_append r.tail [ trigger ]; tail = [] }
+    | T Zero -> Q.singleton trigger
+    | T (One _ as q) -> Q.snoc q trigger
   in
   if Atomic.compare_and_set t before after then begin
     Mutex.unlock_as (Fiber.Maybe.of_fiber fiber) mutex Backoff.default;
@@ -101,3 +63,5 @@ let wait t mutex =
   let fiber = Fiber.current () in
   let trigger = Trigger.create () in
   wait t mutex trigger fiber Backoff.default
+
+let[@inline] signal t = signal t Backoff.default

--- a/lib/picos_sync/picos_sync.ml
+++ b/lib/picos_sync/picos_sync.ml
@@ -1,5 +1,6 @@
 module Mutex = Mutex
 module Condition = Condition
+module Semaphore = Semaphore
 module Lazy = Lazy
 module Event = Event
 module Latch = Latch

--- a/lib/picos_sync/q.ml
+++ b/lib/picos_sync/q.ml
@@ -1,0 +1,72 @@
+type ('a, _) tdt =
+  | Nil : ('a, [> `Nil ]) tdt
+  | Cons : { value : 'a; mutable next : 'a spine } -> ('a, [> `Cons ]) tdt
+
+and 'a spine = S : ('a, [< `Nil | `Cons ]) tdt -> 'a spine [@@unboxed]
+
+type 'a cons = ('a, [ `Cons ]) tdt
+
+external as_cons : 'a spine -> 'a cons = "%identity"
+
+type ('a, _) queue =
+  | Zero : ('a, [> `Zero ]) queue
+  | One : {
+      head : 'a cons;
+      tail : 'a cons;
+      cons : 'a cons;
+    }
+      -> ('a, [> `One ]) queue
+
+type ('a, 'n) one = ('a, ([< `One ] as 'n)) queue
+type 'a t = T : ('a, [< `Zero | `One ]) queue -> 'a t [@@unboxed]
+
+let[@inline] singleton value =
+  let cons = Cons { value; next = S Nil } in
+  T (One { head = cons; tail = cons; cons })
+
+let[@inline] exec (One o : (_, _) one) =
+  if o.tail != o.cons then
+    let (Cons tl) = o.tail in
+    if tl.next != S o.cons then tl.next <- S o.cons
+
+let[@inline] snoc (One o as t : (_, _) one) value =
+  exec t;
+  let cons = Cons { value; next = S Nil } in
+  T (One { head = o.head; tail = o.cons; cons })
+
+let[@inline] head (One { head = Cons hd; _ } : (_, _) one) = hd.value
+
+let[@inline] tail (One o as t : (_, _) one) =
+  exec t;
+  if o.head == o.cons then T Zero
+  else
+    let (Cons hd) = o.head in
+    T (One { head = as_cons hd.next; tail = o.cons; cons = o.cons })
+
+let rec iter (Cons cons_r : _ cons) action =
+  action cons_r.value;
+  match cons_r.next with S Nil -> () | S (Cons _ as cons) -> iter cons action
+
+let[@inline] iter (One o as t : (_, _) one) action =
+  exec t;
+  iter o.head action
+
+let rec find_tail (Cons cons_r as cons : _ cons) =
+  match cons_r.next with S Nil -> cons | S (Cons _ as cons) -> find_tail cons
+
+let[@tail_mod_cons] rec reject (Cons cons_r : _ cons) value =
+  if cons_r.value != value then
+    match cons_r.next with
+    | S Nil -> raise_notrace Not_found
+    | S (Cons _ as cons) ->
+        S (Cons { value = cons_r.value; next = reject cons value })
+  else cons_r.next
+
+let remove (One o as t : (_, _) one) value =
+  exec t;
+  match reject o.head value with
+  | S Nil -> T Zero
+  | S (Cons _ as head) ->
+      let tail = find_tail head in
+      T (One { head; tail; cons = tail })
+  | exception Not_found -> T t

--- a/lib/picos_sync/semaphore.ml
+++ b/lib/picos_sync/semaphore.ml
@@ -1,0 +1,117 @@
+open Picos
+
+let[@inline never] overflow () = raise (Sys_error "overflow")
+let[@inline never] negative () = invalid_arg "negative initial count"
+
+module Counting = struct
+  type t = Obj.t Atomic.t
+
+  let make ?padded count =
+    if count < 0 then negative ();
+    Atomic.make (Obj.repr count) |> Multicore_magic.copy_as ?padded
+
+  let rec release t backoff =
+    let before = Atomic.get t in
+    if Obj.is_int before then begin
+      let count = Obj.obj before in
+      if count < count + 1 then begin
+        let after = Obj.repr (count + 1) in
+        if not (Atomic.compare_and_set t before after) then
+          release t (Backoff.once backoff)
+      end
+      else overflow ()
+    end
+    else
+      let after = Q.tail (Obj.obj before) in
+      if Atomic.compare_and_set t before (Obj.repr after) then
+        let trigger = Q.head (Obj.obj before) in
+        Trigger.signal trigger
+      else release t (Backoff.once backoff)
+
+  let rec cleanup t trigger backoff =
+    let before = Atomic.get t in
+    if Obj.is_int before then release t Backoff.default
+    else
+      let before = Obj.obj before in
+      let after = Q.remove before trigger in
+      if before == after then release t Backoff.default
+      else if not (Atomic.compare_and_set t (Obj.repr before) (Obj.repr after))
+      then cleanup t trigger (Backoff.once backoff)
+
+  let rec acquire t backoff =
+    let before = Atomic.get t in
+    if Obj.is_int before then
+      let count = Obj.obj before in
+      if 0 < count then begin
+        let after = Obj.repr (count - 1) in
+        if not (Atomic.compare_and_set t before after) then
+          acquire t (Backoff.once backoff)
+      end
+      else
+        let trigger = Trigger.create () in
+        let after = Q.singleton trigger in
+        if Atomic.compare_and_set t before (Obj.repr after) then begin
+          match Trigger.await trigger with
+          | None -> ()
+          | Some exn_bt ->
+              cleanup t trigger Backoff.default;
+              Exn_bt.raise exn_bt
+        end
+        else acquire t (Backoff.once backoff)
+    else
+      let trigger = Trigger.create () in
+      let after = Q.snoc (Obj.obj before) trigger in
+      if Atomic.compare_and_set t before (Obj.repr after) then begin
+        match Trigger.await trigger with
+        | None -> ()
+        | Some exn_bt ->
+            cleanup t trigger Backoff.default;
+            Exn_bt.raise exn_bt
+      end
+      else acquire t (Backoff.once backoff)
+
+  let rec try_acquire t backoff =
+    let before = Atomic.get t in
+    Obj.is_int before
+    &&
+    let count = Obj.obj before in
+    0 < count
+    &&
+    let after = Obj.repr (count - 1) in
+    Atomic.compare_and_set t before after
+    || try_acquire t (Backoff.once backoff)
+
+  let get_value t =
+    let state = Atomic.get t in
+    if Obj.is_int state then Obj.obj state else 0
+
+  let[@inline] release t = release t Backoff.default
+  let[@inline] acquire t = acquire t Backoff.default
+  let[@inline] try_acquire t = try_acquire t Backoff.default
+end
+
+module Binary = struct
+  type t = Counting.t
+
+  let make ?padded initial = Counting.make ?padded (Bool.to_int initial)
+
+  let rec release t backoff =
+    let before = Atomic.get t in
+    if Obj.is_int before then begin
+      let count = Obj.obj before in
+      if count = 0 then
+        let after = Obj.repr 1 in
+        if not (Atomic.compare_and_set t before after) then
+          release t (Backoff.once backoff)
+    end
+    else
+      let after = Q.tail (Obj.obj before) in
+      if Atomic.compare_and_set t before (Obj.repr after) then
+        let trigger = Q.head (Obj.obj before) in
+        Trigger.signal trigger
+      else release t (Backoff.once backoff)
+
+  let acquire = Counting.acquire
+  let try_acquire = Counting.try_acquire
+  let[@inline] release t = release t Backoff.default
+end


### PR DESCRIPTION
This PR adds a [Stdlib style `Semaphore` module](https://ocaml.org/manual/5.2/api/Semaphore.html) to the `Picos_sync` library.  The implementation is mainly optimized for size and simplicity in certain respects.  The implementation is not optimized for cancelation.  This also introduces an internal queue `Q` module that is then used also in `Mutex` and `Condition`.