### PR TITLE
Fix `Picos_randos` to count alive fibers correctly

### DIFF
--- a/bench.Dockerfile
+++ b/bench.Dockerfile
@@ -1,5 +1,6 @@
 FROM ocaml/opam:debian-ocaml-5.2
-WORKDIR bench-dir
+WORKDIR /bench-dir
+RUN sudo apt-get update
 RUN sudo ln -sf /usr/bin/opam-2.1 /usr/bin/opam
 RUN sudo chown opam .
 COPY *.opam ./


### PR DESCRIPTION
The code for spawning fibers was probably copied from `Picos_fifos` and was also correct before enhancing `Picos_randos` to support running on multiple cores. With multiple runners the count must be updated before pushing new `Spawn`s into the collection, because otherwise the count may incorrectly become `0` too early.