### PR TITLE
Use scalable `Countdown` in benchmarks

### DIFF
--- a/bench/bench_current.ml
+++ b/bench/bench_current.ml
@@ -4,13 +4,13 @@ open Picos
 let run_one ~budgetf ~n_domains () =
   let n_ops = 100 * Util.iter_factor * n_domains in
 
-  let n_ops_todo = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+  let n_ops_todo = Countdown.create ~n_domains () in
 
-  let init _ = Atomic.set n_ops_todo n_ops in
+  let init _ = Countdown.non_atomic_set n_ops_todo n_ops in
   let wrap _ () = Scheduler.run in
-  let work _ () =
+  let work domain_index () =
     let rec work () =
-      let n = Util.alloc n_ops_todo in
+      let n = Countdown.alloc n_ops_todo ~domain_index ~batch:1000 in
       if n <> 0 then
         let rec loop n =
           if 0 < n then

--- a/bench/bench_fls_excluding_current.ml
+++ b/bench/bench_fls_excluding_current.ml
@@ -8,16 +8,16 @@ let run_one ~budgetf ~n_domains ~op () =
     (match op with `Get -> 800 | `Set -> 400) * Util.iter_factor * n_domains
   in
 
-  let n_ops_todo = Atomic.make 0 |> Multicore_magic.copy_as_padded in
+  let n_ops_todo = Countdown.create ~n_domains () in
 
-  let init _ = Atomic.set n_ops_todo n_ops in
+  let init _ = Countdown.non_atomic_set n_ops_todo n_ops in
   let wrap _ () = Scheduler.run in
-  let work _ () =
+  let work domain_index () =
     let fiber = Fiber.current () in
     match op with
     | `Get ->
         let rec work () =
-          let n = Util.alloc n_ops_todo in
+          let n = Countdown.alloc n_ops_todo ~domain_index ~batch:1000 in
           if n <> 0 then
             let rec loop n =
               if 0 < n then begin
@@ -31,7 +31,7 @@ let run_one ~budgetf ~n_domains ~op () =
         work ()
     | `Set ->
         let rec work () =
-          let n = Util.alloc n_ops_todo in
+          let n = Countdown.alloc n_ops_todo ~domain_index ~batch:1000 in
           if n <> 0 then
             let rec loop n =
               if 0 < n then begin

--- a/bench/countdown.ml
+++ b/bench/countdown.ml
@@ -1,0 +1,60 @@
+module Atomic = Multicore_magic.Transparent_atomic
+
+type t = int Atomic.t array
+
+let ceil_pow_2_minus_1 n =
+  let n = Nativeint.of_int n in
+  let n = Nativeint.logor n (Nativeint.shift_right_logical n 1) in
+  let n = Nativeint.logor n (Nativeint.shift_right_logical n 2) in
+  let n = Nativeint.logor n (Nativeint.shift_right_logical n 4) in
+  let n = Nativeint.logor n (Nativeint.shift_right_logical n 8) in
+  let n = Nativeint.logor n (Nativeint.shift_right_logical n 16) in
+  Nativeint.to_int
+    (if Sys.int_size > 32 then
+       Nativeint.logor n (Nativeint.shift_right_logical n 32)
+     else n)
+
+let create ~n_domains () =
+  if n_domains < 1 then invalid_arg "n_domains < 1";
+  let n = ceil_pow_2_minus_1 n_domains in
+  let atomics = Array.init n_domains (fun _ -> Atomic.make_contended 0) in
+  Array.init n @@ fun i -> Array.unsafe_get atomics (i mod n_domains)
+
+let rec arity t i =
+  if i < Array.length t && Array.unsafe_get t i != Array.unsafe_get t 0 then
+    arity t (i + 1)
+  else i
+
+let[@inline] arity t = arity t 1
+
+let non_atomic_set t count =
+  if count < 0 then invalid_arg "count < 0";
+  let n = arity t in
+  let d = count / n in
+  let j = count - (n * d) in
+  for i = 0 to n - 1 do
+    Atomic.set (Array.unsafe_get t i) (d + Bool.to_int (i < j))
+  done
+
+let rec get t count i =
+  if i < Array.length t && Array.unsafe_get t i != Array.unsafe_get t 0 then
+    get t (count + Int.max 0 (Atomic.get (Array.unsafe_get t i))) (i + 1)
+  else count
+
+let[@inline] get t = get t (Int.max 0 (Atomic.get (Array.unsafe_get t 0))) 1
+
+let rec alloc t ~batch i =
+  if i < Array.length t then
+    let c = Array.unsafe_get t i in
+    if 0 < Atomic.get c then
+      let n = Atomic.fetch_and_add c (-batch) in
+      if 0 < n then Int.min n batch else alloc t ~batch (i + 1)
+    else alloc t ~batch (i + 1)
+  else 0
+
+let[@inline] alloc t ~domain_index ~batch =
+  let c = Array.unsafe_get t domain_index in
+  if 0 < Atomic.get c then
+    let n = Atomic.fetch_and_add c (-batch) in
+    if 0 < n then Int.min n batch else alloc t ~batch 0
+  else alloc t ~batch 0

--- a/bench/countdown.mli
+++ b/bench/countdown.mli
@@ -1,0 +1,24 @@
+(** Scalable low-level countdown. *)
+
+type t
+(** Represents a countdown counter. *)
+
+val create : n_domains:int -> unit -> t
+(** [create ~n_domains ()] returns a new countdown counter with initial value of
+    [0]. *)
+
+val non_atomic_set : t -> int -> unit
+(** [non_atomic_set countdown count] sets the [count] of the [countdown].
+
+    ⚠️ This operation is not atomic.  However, it is safe to call
+    [non_atomic_set] with the same [countdown] and [count] in parallel, because
+    the [countdown] will be initialized deterministically. *)
+
+val get : t -> int
+(** [get countdown] returns the count of the [countdown]. *)
+
+val alloc : t -> domain_index:int -> batch:int -> int
+(** [alloc countdown ~domain_index ~batch] tries to reduce the count of the
+    [countdown] by at most [batch] (which must be positive) and returns the
+    number by which the count was reduced or [0] in case the count was already
+    [0]. *)


### PR DESCRIPTION
This should reduce contention in benchmarks and potentially give more precise and accurate results.