### PR TITLE
Fix bounded queue example to use `Condition.broadcast`

### DIFF
--- a/lib/picos_sync/picos_sync.mli
+++ b/lib/picos_sync/picos_sync.mli
@@ -369,7 +369,7 @@ end
             Queue.length t.queue = 1
           in
           if was_empty then
-            Condition.signal t.not_empty
+            Condition.broadcast t.not_empty
 
         let pop t =
           let elem, was_full =
@@ -382,7 +382,7 @@ end
             Queue.pop t.queue, was_full
           in
           if was_full then
-            Condition.signal t.not_full;
+            Condition.broadcast t.not_full;
           elem
       end
     ]}

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -241,10 +241,10 @@ let test_race_any () =
     Test_util.shuffle
       [
         (fun () ->
-          Control.sleep ~seconds:0.9;
+          Control.sleep ~seconds:2.9;
           winner := 3);
         (fun () ->
-          Control.sleep ~seconds:0.5;
+          Control.sleep ~seconds:1.5;
           winner := 2);
         (fun () ->
           Control.sleep ~seconds:0.1;


### PR DESCRIPTION
Using `Condition.signal` is not correct in these cases, because it is possible that multiple fibers manage to start `Condition.wait` and a single `Condition.signal` does not wake up all of them.  Another alternative would be to `Condition.signal` every time the queue is not empty or is not full.