### PR TITLE
Add incremental or single-assignment poisonable variable

### DIFF
--- a/lib/picos_structured/picos_structured.mli
+++ b/lib/picos_structured/picos_structured.mli
@@ -89,6 +89,26 @@ module Finally : sig
       Another alternative to avoiding leaks is to {{!let@} recursively fork
       fibers to accept and handle a client}.
 
+      You can [move] a resource between any two fibers.  For example, you can
+      move a resource from a child fiber to the parent fiber:
+
+      {@ocaml skip[
+        let moveable_ivar = Ivar.create () in
+
+        Bundle.fork bundle begin fun () ->
+          let^ moveable =
+            finally (* dispose *) (* allocate *)
+          in
+          Ivar.fill moveable_ivar moveable
+        end;
+
+        let@ res = move (Ivar.read moveable_ivar) in
+        (* ... *)
+      ]}
+
+      The above uses an {{!Picos_sync.Ivar} [Ivar]} to communicate the moveable
+      resource from the child fiber to the parent fiber.
+
       @raise Invalid_argument if the resource has already been moved (or
         released) unless the fiber has been canceled. *)
 end

--- a/lib/picos_sync/ivar.ml
+++ b/lib/picos_sync/ivar.ml
@@ -1,0 +1,16 @@
+open Picos
+
+type 'a t = 'a Computation.t
+
+let create () = Computation.create ()
+let of_value = Computation.returned
+let try_fill = Computation.try_return
+let fill = Computation.return
+let try_poison = Computation.try_cancel
+let poison = Computation.cancel
+
+let peek ivar =
+  if Computation.is_running ivar then None else Some (Computation.await ivar)
+
+let read = Computation.await
+let read_evt = Event.from_computation

--- a/lib/picos_sync/picos_sync.ml
+++ b/lib/picos_sync/picos_sync.ml
@@ -3,3 +3,4 @@ module Condition = Condition
 module Lazy = Lazy
 module Event = Event
 module Latch = Latch
+module Ivar = Ivar


### PR DESCRIPTION
An `Ivar` can be implemented trivially using a `Computation`.

This PR also adds an example of how one can move resources between threads using the resource management helpers provided by the `Picos_structured.Finally` module.