### PR TITLE
Redesign resource management to use only one binding operator

### DIFF
--- a/lib/picos_finally/picos_finally.mli
+++ b/lib/picos_finally/picos_finally.mli
@@ -16,73 +16,65 @@
 
 (** {1 API} *)
 
-(** {2 Resource templates} *)
+(** {2 Basics} *)
 
-type 'resource template
-(** Represents a resource template of release and acquire functions. *)
+val ( let@ ) : ('a -> 'b) -> 'a -> 'b
+(** [let@ resource = template in scope] is equivalent to
+    [template (fun resource -> scope)].
 
-val finally : ('r -> unit) -> (unit -> 'r) -> 'r template
-(** [finally release acquire] returns a resource template with the given
-    [release] and [acquire] functions. *)
+    ℹ️ You can use this binding operator with any [template] function that has a
+    type of the form [('r -> 'a) -> 'a]. *)
 
-(** {2 Managed instances}
+val finally : ('r -> unit) -> (unit -> 'r) -> ('r -> 'a) -> 'a
+(** [finally release acquire scope] calls [acquire ()] to obtain a [resource],
+    calls [scope resource], and then calls [release resource] after the scope
+    exits. *)
 
-    A resource instance can be first acquired in one scope and then moved to
-    another scope. *)
+(** {2 Instances} *)
 
-type 'resource instance
-(** Either contains a resource or is empty as the resource has been {{!move}
-    moved}, {{!release} released}, or has been {{!let&} borrowed}
+type 'r instance
+(** Either contains a resource or is empty as the resource has been {{!transfer}
+    transferred}, {{!drop} dropped}, or has been {{!borrow} borrowed}
     temporarily. *)
 
-val ( let^ ) : 'r template -> ('r instance -> 'a) -> 'a
-(** [let^ instance = finally release acquire in scope] calls [acquire ()] to
-    obtain a resource and stores it as a resource [instance].  Then, at the end
-    of [scope], awaits that the [instance] is {{!move} moved} or {{!release}
-    released}, or {{!release} releases} the resource in case an error has been
-    raised or the fiber has been canceled.
+val instantiate : ('r -> unit) -> (unit -> 'r) -> ('r instance -> 'a) -> 'a
+(** [instantiate release acquire scope] calls [acquire ()] to obtain a resource
+    and stores it as an {!instance}, calls [scope instance].  Then, if [scope]
+    returns normally, awaits until the {!instance} becomes empty.  In case
+    [scope] raises an exception or the fiber is canceled, the instance will be
+    {{!drop} dropped}. *)
 
-    💡 In other words, you are expected to either {!move} or {!release} the
-    resource.  [let^] only makes sure that the resource is released in case
-    something goes wrong. *)
-
-val release : 'r instance -> unit
-(** [release instance] releases the resource, if any, contained by the
-    [instance].
+val drop : 'r instance -> unit
+(** [drop instance] releases the resource, if any, contained by the {!instance}.
 
     @raise Invalid_argument if the resource has been {{!let&} borrowed} and
       hasn't yet been returned. *)
 
-val move : 'r instance -> 'r template
-(** [move instance] returns a resource {!template} where the acquire operation
-    atomically takes the resource from the [instance] and signals the previous
-    owner, and the release operation releases the resource.
+val borrow : 'r instance -> ('r -> 'a) -> 'a
+(** [borrow instance scope] borrows the [resource] stored in the [instance],
+    calls [scope resource], and then returns the [resource] to the [instance]
+    after scope exits.
 
-    ℹ️ [move] operates lazily such that either party in a transfer may call
-    [move].  The transfer takes place atomically at the point the {!template}
-    returned by [move] is {{!let@} bound} to a scope.
+    @raise Invalid_argument if the resource has already been {{!borrow}
+      borrowed} and hasn't yet been returned, has already been {{!drop}
+      dropped}, or has already been {{!transfer} transferred}. *)
 
-    @raise Invalid_argument if the resource has been {{!let&} borrowed} and
-      hasn't yet been returned, has already been {{!move} moved}, or has been
-      {{!release} released} unless the current fiber has been canceled, in which
-      case the exception that the fiber was canceled with will be raised. *)
+val transfer : 'r instance -> ('r instance -> 'a) -> 'a
+(** [transfer source] transfers the [resource] stored in the [source] instance
+    into a new [target] instance, calls [scope target].  Then, if [scope]
+    returns normally, awaits until the [target] instance becomes empty.  In case
+    [scope] raises an exception or the fiber is canceled, the [target] instance
+    will be {{!drop} dropped}.
 
-(** {2 Naked resources}
+    @raise Invalid_argument if the resource has been {{!borrow} borrowed} and
+      hasn't yet been returned, has already been {{!transfer} transferred}, or
+      has been {{!drop} dropped} unless the current fiber has been canceled, in
+      which case the exception that the fiber was canceled with will be
+      raised. *)
 
-    A naked resource cannot escape the scope in which it was acquired. *)
-
-val ( let@ ) : 'r template -> ('r -> 'a) -> 'a
-(** [let@ resource = finally release acquire in scope] calls [acquire ()] to
-    obtain a [resource], evaluates [scope], and calls [release resource]
-    whether [scope] returns normally or raises an exception. *)
-
-val ( let& ) : 'r instance -> ('r -> 'a) -> 'a
-(** [let& resource = instance in scope] borrows the [resource] held by the
-    [instance] for the duration of the [scope].
-
-    @raise Invalid_argument if the resource has already been {{!let&} borrowed}
-      and hasn't yet been returned, has already been {{!release} released}, or
-      has already been {{!move} moved}. *)
+val move : 'r instance -> ('r -> 'a) -> 'a
+(** [move instance scope] is equivalent to
+    {{!transfer} [transfer instance (fun instance -> borrow instance scope)]}. *)
 
 (** {1 Examples}
 
@@ -114,8 +106,8 @@ val ( let& ) : 'r instance -> ('r -> 'a) -> 'a
 
     {2 Looping server}
 
-    There is also a way to {!move} resources to allow forking fibers to handle
-    clients without leaks.
+    There is also a way to {{!move} move} {{!instantiate} instantiated}
+    resources to allow forking fibers to handle clients without leaks.
 
     Here is a sketch of a server that accepts in a loop and forks fibers to
     handle clients:
@@ -126,8 +118,8 @@ val ( let& ) : 'r instance -> ('r -> 'a) -> 'a
 
         (* loop to accept clients *)
         while true do
-          let^ client_fd =
-            finally Unix.close @@ fun () ->
+          let@ client_fd =
+            instantiate Unix.close @@ fun () ->
             Unix.accept ~cloexec:true server_fd
             |> fst
           in
@@ -143,9 +135,10 @@ val ( let& ) : 'r instance -> ('r -> 'a) -> 'a
 
     {2 Move resource from child to parent}
 
-    You can {!move} a resource between any two fibers and {{!let&} borrow} it
-    before moving it.  For example, you can create a resource in a child fiber,
-    use it there, and then move it to the parent fiber:
+    You can {{!move} move} an {{!instantiate} instantiated} resource between any
+    two fibers and {{!borrow} borrow} it before moving it.  For example, you can
+    create a resource in a child fiber, use it there, and then move it to the
+    parent fiber:
 
     {[
       let move_from_child_to_parent () =
@@ -160,13 +153,13 @@ val ( let& ) : 'r instance -> ('r -> 'a) -> 'a
           and pretend_acquire () = () in
 
           (* allocate a resource *)
-          let^ instance =
-            finally pretend_release pretend_acquire
+          let@ instance =
+            instantiate pretend_release pretend_acquire
           in
 
           begin
             (* borrow the resource *)
-            let& resource = instance in
+            let@ resource = borrow instance in
 
             (* use the resource... omitted *)
             ()

--- a/lib/picos_structured/picos_structured.mli
+++ b/lib/picos_structured/picos_structured.mli
@@ -476,8 +476,8 @@ end
 
         Bundle.join_after begin fun bundle ->
           while true do
-            let^ client_fd =
-              finally Unix.close @@ fun () ->
+            let@ client_fd =
+              instantiate Unix.close @@ fun () ->
               Unix.accept
                 ~cloexec:true server_fd |> fst
             in

--- a/test/test_finally.ml
+++ b/test/test_finally.ml
@@ -2,10 +2,10 @@ open Picos_finally
 
 let test_move_is_lazy () =
   Test_scheduler.run @@ fun () ->
-  let^ moveable = finally Fun.id Fun.id in
-  release moveable;
+  let@ moveable = instantiate Fun.id Fun.id in
+  drop moveable;
   begin
-    match move moveable with _ -> () | exception _ -> assert false
+    match (move moveable : _ -> _) with _ -> () | exception _ -> assert false
   end;
   begin
     match
@@ -18,9 +18,9 @@ let test_move_is_lazy () =
 
 let test_borrow_returns_resource () =
   Test_scheduler.run @@ fun () ->
-  let^ moveable = finally Fun.id Fun.id in
+  let@ moveable = instantiate Fun.id Fun.id in
   begin
-    let& _ = moveable in
+    let@ _ = borrow moveable in
     ()
   end;
   let@ _ = move moveable in
@@ -29,7 +29,7 @@ let test_borrow_returns_resource () =
 let () =
   [
     ("move", [ Alcotest.test_case "is lazy" `Quick test_move_is_lazy ]);
-    ( "let&",
+    ( "borrow",
       [
         Alcotest.test_case "returns resource" `Quick
           test_borrow_returns_resource;

--- a/test/test_server_and_client.ml
+++ b/test/test_server_and_client.ml
@@ -39,8 +39,8 @@ let main () =
         Printf.printf "  Server listening\n%!";
         Bundle.join_after @@ fun bundle ->
         while true do
-          let^ client =
-            finally Unix.close @@ fun () ->
+          let@ client =
+            instantiate Unix.close @@ fun () ->
             Printf.printf "  Server accepting\n%!";
             Unix.accept ~cloexec:true socket |> fst
           in


### PR DESCRIPTION
This changes `Picos_finally` to use `let (let@) = (@@)` as the only binding operator.

Thanks to @c-cube and @edwintorok for discussion on this topic! 