### PR TITLE
Add an implicitly propagated flock of fibers

### DIFF
--- a/bench/bench_bounded_q.ml
+++ b/bench/bench_bounded_q.ml
@@ -118,8 +118,8 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
   in
   let wrap _ () = Scheduler.run in
   let work domain_index () =
-    Bundle.join_after @@ fun bundle ->
-    Bundle.fork bundle yielder;
+    Flock.join_after @@ fun () ->
+    Flock.fork yielder;
     if domain_index < n_adders then
       let rec work () =
         let n = Countdown.alloc n_msgs_to_add ~domain_index ~batch:100 in
@@ -129,7 +129,7 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
           done;
           work ()
         end
-        else Bundle.terminate bundle
+        else Flock.terminate ()
       in
       work ()
     else
@@ -141,7 +141,7 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
           done;
           work ()
         end
-        else Bundle.terminate bundle
+        else Flock.terminate ()
       in
       work ()
   in

--- a/bench/bench_cancel_after.ml
+++ b/bench/bench_cancel_after.ml
@@ -45,7 +45,7 @@ let run_async ~budgetf ~n_domains () =
   let init _ = Countdown.non_atomic_set n_ops_todo n_ops in
   let wrap _ () = Scheduler.run in
   let work domain_index () =
-    Bundle.join_after @@ fun bundle ->
+    Flock.join_after @@ fun () ->
     let queue = Queue.create () in
     let exit = ref false in
 
@@ -56,7 +56,7 @@ let run_async ~budgetf ~n_domains () =
           Computation.wait computation;
           awaiter ()
     in
-    Bundle.fork bundle awaiter;
+    Flock.fork awaiter;
 
     let rec work () =
       let n = Countdown.alloc n_ops_todo ~domain_index ~batch:10 in

--- a/bench/bench_mutex.ml
+++ b/bench/bench_mutex.ml
@@ -26,7 +26,7 @@ let run_one ~budgetf ~n_fibers ~use_domains () =
   in
   let wrap _ () = Scheduler.run in
   let work domain_index () =
-    Bundle.join_after @@ fun bundle ->
+    Flock.join_after @@ fun () ->
     let rec work () =
       let n = Countdown.alloc n_ops_todo ~domain_index ~batch in
       if n <> 0 then
@@ -46,13 +46,13 @@ let run_one ~budgetf ~n_fibers ~use_domains () =
         loop n
     in
     if use_domains then begin
-      Bundle.fork bundle yielder;
+      Flock.fork yielder;
       work ();
-      Bundle.terminate bundle
+      Flock.terminate ()
     end
     else
       for _ = 1 to n_fibers do
-        Bundle.fork bundle work
+        Flock.fork work
       done
   in
 

--- a/bench/bench_yield.ml
+++ b/bench/bench_yield.ml
@@ -12,14 +12,14 @@ let run_one ~budgetf ~n_fibers () =
   let init _ = () in
   let wrap _ () = Scheduler.run in
   let work _ () =
-    Bundle.join_after @@ fun bundle ->
+    Flock.join_after @@ fun () ->
     let main () =
       for _ = 1 to n_yields_per_fiber do
         Control.yield ()
       done
     in
     for _ = 1 to n_fibers do
-      Bundle.fork bundle main
+      Flock.fork main
     done
   in
   let config =

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -153,11 +153,11 @@ module Trigger : sig
 
       {[
         run begin fun () ->
-          Bundle.join_after @@ fun bundle ->
+          Flock.join_after @@ fun () ->
 
           let trigger = Trigger.create () in
 
-          Bundle.fork bundle begin fun () ->
+          Flock.fork begin fun () ->
             Trigger.signal trigger
           end;
 
@@ -428,20 +428,20 @@ module Computation : sig
 
       {[
         run begin fun () ->
-          Bundle.join_after @@ fun bundle ->
+          Flock.join_after @@ fun () ->
 
           let computation =
             Computation.create ()
           in
 
-          let canceler = Bundle.fork_as_promise bundle @@ fun () ->
+          let canceler = Flock.fork_as_promise @@ fun () ->
             Fiber.sleep ~seconds:1.0;
 
             Computation.cancel computation
               (Exn_bt.get_callstack 0 Exit)
           in
 
-          Bundle.fork bundle begin fun () ->
+          Flock.fork begin fun () ->
             let rec fib i =
               Computation.check
                 computation;

--- a/lib/picos_finally/picos_finally.mli
+++ b/lib/picos_finally/picos_finally.mli
@@ -85,7 +85,7 @@ val move : 'r instance -> ('r -> 'a) -> 'a
 
     {[
       let recursive_server server_fd =
-        Bundle.join_after @@ fun bundle ->
+        Flock.join_after @@ fun () ->
 
         (* recursive server *)
         let rec accept () =
@@ -96,12 +96,12 @@ val move : 'r instance -> ('r -> 'a) -> 'a
           in
 
           (* fork to accept other clients *)
-          Bundle.fork bundle accept;
+          Flock.fork accept;
 
           (* handle this client... omitted *)
           ()
         in
-        Bundle.fork bundle accept
+        Flock.fork accept
     ]}
 
     {2 Looping server}
@@ -114,7 +114,7 @@ val move : 'r instance -> ('r -> 'a) -> 'a
 
     {[
       let looping_server server_fd =
-        Bundle.join_after @@ fun bundle ->
+        Flock.join_after @@ fun () ->
 
         (* loop to accept clients *)
         while true do
@@ -125,7 +125,7 @@ val move : 'r instance -> ('r -> 'a) -> 'a
           in
 
           (* fork to handle this client *)
-          Bundle.fork bundle @@ fun () ->
+          Flock.fork @@ fun () ->
             let@ client_fd = move client_fd in
 
             (* handle client... omitted *)
@@ -142,13 +142,13 @@ val move : 'r instance -> ('r -> 'a) -> 'a
 
     {[
       let move_from_child_to_parent () =
-        Bundle.join_after @@ fun bundle ->
+        Flock.join_after @@ fun () ->
 
         (* for communicating a resource *)
         let shared_ivar = Ivar.create () in
 
         (* fork a child that creates a resource *)
-        Bundle.fork bundle begin fun () ->
+        Flock.fork begin fun () ->
           let pretend_release () = ()
           and pretend_acquire () = () in
 

--- a/lib/picos_select/picos_select.mli
+++ b/lib/picos_select/picos_select.mli
@@ -186,8 +186,8 @@ val check_configured : unit -> unit
           assert (w = 1)
         in
 
-        Bundle.join_after begin fun bundle ->
-          Bundle.fork bundle begin fun () ->
+        Flock.join_after begin fun () ->
+          Flock.fork begin fun () ->
             while true do
               Event.select [
                 Picos_select.on msg_inn1 `R
@@ -217,7 +217,7 @@ val check_configured : unit -> unit
           write1 msg_out2;
           read1 syn_inn;
 
-          Bundle.terminate bundle
+          Flock.terminate ()
         end
       Inn1
       Inn2

--- a/lib/picos_stdio/picos_stdio.mli
+++ b/lib/picos_stdio/picos_stdio.mli
@@ -718,8 +718,8 @@ end
         Unix.set_nonblock syn_i;
         Unix.set_nonblock syn_o;
 
-        Bundle.join_after begin fun bundle ->
-          Bundle.fork bundle begin fun () ->
+        Flock.join_after begin fun () ->
+          Flock.fork begin fun () ->
             let bytes = Bytes.create 100 in
             while true do
               let n =
@@ -753,7 +753,7 @@ end
           send_string "Hello, world!";
           send_string "POSIX with OCaml";
 
-          Bundle.terminate bundle
+          Flock.terminate ()
         end
       Hello, world!
       POSIX with OCaml

--- a/lib/picos_structured/bundle.ml
+++ b/lib/picos_structured/bundle.ml
@@ -2,83 +2,109 @@ open Picos
 
 let[@inline never] completed () = invalid_arg "already completed"
 
-type t = {
-  num_fibers : int Atomic.t;
-  bundle : unit Computation.t;
-  errors : Control.Errors.t;
-  finished : Trigger.t;
-}
+type _ tdt =
+  | Nothing : [> `Nothing ] tdt
+  | Bundle : {
+      num_fibers : int Atomic.t;
+      bundle : unit Computation.t;
+      errors : Control.Errors.t;
+      finished : Trigger.t;
+    }
+      -> [> `Bundle ] tdt
 
-let terminate ?callstack t =
-  Computation.cancel t.bundle (Control.terminate_bt ?callstack ())
+let flock_key : [ `Bundle | `Nothing ] tdt Fiber.FLS.key =
+  Fiber.FLS.new_key (Constant Nothing)
 
-let terminate_after ?callstack t ~seconds =
-  Computation.cancel_after t.bundle ~seconds
+type t = [ `Bundle ] tdt
+
+let terminate ?callstack (Bundle r : t) =
+  Computation.cancel r.bundle (Control.terminate_bt ?callstack ())
+
+let terminate_after ?callstack (Bundle r : t) ~seconds =
+  Computation.cancel_after r.bundle ~seconds
     (Control.terminate_bt ?callstack ())
 
-let error ?callstack t (exn_bt : Exn_bt.t) =
+let error ?callstack (Bundle r as t : t) (exn_bt : Exn_bt.t) =
   if exn_bt.Exn_bt.exn != Control.Terminate then begin
     terminate ?callstack t;
-    Control.Errors.push t.errors exn_bt
+    Control.Errors.push r.errors exn_bt
   end
 
-let decr t =
-  let n = Atomic.fetch_and_add t.num_fibers (-1) in
+let decr (Bundle r : t) =
+  let n = Atomic.fetch_and_add r.num_fibers (-1) in
   if n = 1 then begin
-    Computation.finish t.bundle;
-    Trigger.signal t.finished
+    Computation.finish r.bundle;
+    Trigger.signal r.finished
   end
 
-let await t fiber packed canceler =
+type _ pass = FLS : unit pass | Arg : t pass
+
+let await (type a) (Bundle r as t : t) fiber packed canceler outer
+    (pass : a pass) =
   decr t;
   Fiber.set_computation fiber packed;
   let forbid = Fiber.exchange fiber ~forbid:true in
-  Trigger.await t.finished |> ignore;
+  Trigger.await r.finished |> ignore;
   Fiber.set fiber ~forbid;
+  begin
+    match pass with FLS -> Fiber.FLS.set fiber flock_key outer | Arg -> ()
+  end;
   let (Packed parent) = packed in
   Computation.detach parent canceler;
-  Control.Errors.check t.errors;
+  Control.Errors.check r.errors;
   Fiber.check fiber
 
-let join_after fn =
+let join_after_pass (type a) (fn : a -> _) (pass : a pass) =
   (* The sequence of operations below ensures that nothing is leaked. *)
-  let t =
+  let (Bundle r as t : t) =
     let num_fibers = Atomic.make 1 in
     let bundle = Computation.create ~mode:`LIFO () in
     let errors = Control.Errors.create () in
     let finished = Trigger.create () in
-    { num_fibers; bundle; errors; finished }
+    Bundle { num_fibers; bundle; errors; finished }
   in
   let fiber = Fiber.current () in
+  let outer =
+    match pass with FLS -> Fiber.FLS.get fiber flock_key | Arg -> Nothing
+  in
   let (Packed parent as packed) = Fiber.get_computation fiber in
-  let bundle = Computation.Packed t.bundle in
-  let canceler = Computation.attach_canceler ~from:parent ~into:t.bundle in
+  let bundle = Computation.Packed r.bundle in
+  let canceler = Computation.attach_canceler ~from:parent ~into:r.bundle in
   (* Ideally there should be no poll point betweem [attach_canceler] and the
      [match ... with] below. *)
-  Fiber.set_computation fiber bundle;
-  match fn t with
+  match
+    Fiber.set_computation fiber bundle;
+    fn (match pass with FLS -> Fiber.FLS.set fiber flock_key t | Arg -> t)
+  with
   | value ->
-      await t fiber packed canceler;
+      await t fiber packed canceler outer pass;
       value
   | exception exn ->
       let exn_bt = Exn_bt.get exn in
       error t exn_bt;
-      await t fiber packed canceler;
+      await t fiber packed canceler outer pass;
       Exn_bt.raise exn_bt
 
-let rec incr t backoff =
-  let before = Atomic.get t.num_fibers in
+let join_after fn = join_after_pass fn Arg
+
+let rec incr (Bundle r as t : t) backoff =
+  let before = Atomic.get r.num_fibers in
   if before = 0 then completed ()
-  else if not (Atomic.compare_and_set t.num_fibers before (before + 1)) then
+  else if not (Atomic.compare_and_set r.num_fibers before (before + 1)) then
     incr t (Backoff.once backoff)
 
-let fork_as_promise t thunk =
+let fork_as_promise_pass (type a) (Bundle r as t : t) thunk (pass : a pass) =
   (* The sequence of operations below ensures that nothing is leaked. *)
   incr t Backoff.default;
   let child = Computation.create ~mode:`LIFO () in
   try
-    let canceler = Computation.attach_canceler ~from:t.bundle ~into:child in
+    let canceler = Computation.attach_canceler ~from:r.bundle ~into:child in
     let main () =
+      begin
+        match pass with
+        | FLS -> Fiber.FLS.set (Fiber.current ()) flock_key t
+        | Arg -> ()
+      end;
       begin
         match thunk () with
         | value -> Computation.return child value
@@ -87,7 +113,7 @@ let fork_as_promise t thunk =
             Computation.cancel child exn_bt;
             error t exn_bt
       end;
-      Computation.detach t.bundle canceler;
+      Computation.detach r.bundle canceler;
       decr t
     in
     Fiber.spawn ~forbid:false child [ main ];
@@ -98,10 +124,11 @@ let fork_as_promise t thunk =
     decr t;
     raise canceled_exn
 
+let fork_as_promise t thunk = fork_as_promise_pass t thunk Arg
 let fork t thunk = fork_as_promise t thunk |> ignore
 
 (* *)
 
-let is_running t = Computation.is_running t.bundle
-let unsafe_incr t = Atomic.incr t.num_fibers
-let unsafe_reset t = Atomic.set t.num_fibers 1
+let is_running (Bundle r : t) = Computation.is_running r.bundle
+let unsafe_incr (Bundle r : t) = Atomic.incr r.num_fibers
+let unsafe_reset (Bundle r : t) = Atomic.set r.num_fibers 1

--- a/lib/picos_structured/flock.ml
+++ b/lib/picos_structured/flock.ml
@@ -1,0 +1,17 @@
+open Picos
+
+let[@inline never] no_flock () = invalid_arg "no flock"
+
+let get () =
+  match Fiber.FLS.get (Fiber.current ()) Bundle.flock_key with
+  | Nothing -> no_flock ()
+  | Bundle _ as t -> t
+
+let terminate_after ?callstack ~seconds () =
+  Bundle.terminate_after ?callstack (get ()) ~seconds
+
+let terminate ?callstack () = Bundle.terminate ?callstack (get ())
+let error ?callstack exn_bt = Bundle.error (get ()) ?callstack exn_bt
+let fork_as_promise thunk = Bundle.fork_as_promise_pass (get ()) thunk FLS
+let fork action = fork_as_promise action |> ignore
+let join_after fn = Bundle.join_after_pass fn Bundle.FLS

--- a/lib/picos_structured/picos_structured.ml
+++ b/lib/picos_structured/picos_structured.ml
@@ -1,4 +1,5 @@
 module Control = Control
 module Promise = Promise
 module Bundle = Bundle
+module Flock = Flock
 module Run = Run

--- a/lib/picos_structured/run.ml
+++ b/lib/picos_structured/run.ml
@@ -20,10 +20,10 @@ let wrap_any t main =
     Bundle.decr t
 
 let run actions wrap =
-  Bundle.join_after @@ fun t ->
+  Bundle.join_after @@ fun (Bundle r as t : Bundle.t) ->
   try
     let mains = List.map (wrap t) actions in
-    Fiber.spawn ~forbid:false t.bundle mains
+    Fiber.spawn ~forbid:false r.bundle mains
   with exn ->
     Bundle.unsafe_reset t;
     raise exn

--- a/lib/picos_sync/picos_sync.mli
+++ b/lib/picos_sync/picos_sync.mli
@@ -502,8 +502,8 @@ end
           Bounded_q.create ~capacity:3
         in
 
-        Bundle.join_after begin fun bundle ->
-          Bundle.fork bundle begin fun () ->
+        Flock.join_after begin fun () ->
+          Flock.fork begin fun () ->
             while true do
               Printf.printf "Popped %d\n%!"
                 (Bounded_q.pop bq)
@@ -519,7 +519,7 @@ end
 
           Control.yield ();
 
-          Bundle.terminate bundle
+          Flock.terminate ()
         end;
 
         Printf.printf "Pushing %d\n%!" 101;

--- a/test/test_lwt_unix.ml
+++ b/test/test_lwt_unix.ml
@@ -3,9 +3,9 @@ open Picos_structured
 let basics () =
   Lwt_main.run @@ Picos_lwt_unix.run
   @@ fun () ->
-  Bundle.join_after @@ fun bundle ->
+  Flock.join_after @@ fun () ->
   let child =
-    Bundle.fork_as_promise bundle @@ fun () ->
+    Flock.fork_as_promise @@ fun () ->
     while true do
       Picos_lwt.await (Lwt_unix.sleep 0.01)
     done

--- a/test/test_picos_lwt_unix_with_cohttp.ml
+++ b/test/test_picos_lwt_unix_with_cohttp.ml
@@ -7,12 +7,12 @@ open Cohttp_lwt_unix
 let await = Picos_lwt.await
 
 let main () =
-  Bundle.join_after @@ fun bundle ->
+  Flock.join_after @@ fun () ->
   (* We use the [Picos_structured] library for structured concurrency. *)
 
   (* First we start the server. *)
   let server =
-    Bundle.fork_as_promise bundle @@ fun () ->
+    Flock.fork_as_promise @@ fun () ->
     let callback _conn req body =
       let uri = req |> Request.uri |> Uri.to_string in
       let meth = req |> Request.meth |> Code.string_of_method in

--- a/test/test_schedulers.ml
+++ b/test/test_schedulers.ml
@@ -36,8 +36,8 @@ let test_current () =
   Test_scheduler.run ~max_domains:2 @@ fun () ->
   let fiber_parent = Fiber.current () in
   let fiber_child = ref fiber_parent in
-  Bundle.join_after @@ fun bundle ->
-  Bundle.fork bundle (fun () -> fiber_child := Fiber.current ());
+  Flock.join_after @@ fun () ->
+  Flock.fork (fun () -> fiber_child := Fiber.current ());
   while fiber_parent == !fiber_child do
     Control.yield ()
   done

--- a/test/test_select.ml
+++ b/test/test_select.ml
@@ -12,9 +12,9 @@ let test_intr () =
   in
   let main () =
     Picos_threaded.run @@ fun () ->
-    Bundle.join_after @@ fun bundle ->
+    Flock.join_after @@ fun () ->
     for _ = 1 to 10 do
-      Bundle.fork bundle @@ fun () ->
+      Flock.fork @@ fun () ->
       for _ = 1 to 1_000 do
         let req = Picos_select.Intr.req ~seconds:0.000_001 in
         match Unix.read inn (Bytes.create 1) 0 1 with

--- a/test/test_stdio.ml
+++ b/test/test_stdio.ml
@@ -46,14 +46,14 @@ let test_select_empty_timeout () =
 
 let test_select_empty_forever () =
   Test_scheduler.run ~max_domains:2 @@ fun () ->
-  Bundle.join_after @@ fun bundle ->
+  Flock.join_after @@ fun () ->
   begin
-    Bundle.fork bundle @@ fun () ->
+    Flock.fork @@ fun () ->
     let _ = Unix.select [] [] [] (-1.0) in
     Printf.printf "Impossible\n%!"
   end;
   Unix.sleepf 0.01;
-  Bundle.terminate bundle
+  Flock.terminate ()
 
 let test_select () =
   Test_scheduler.run ~max_domains:2 @@ fun () ->
@@ -79,9 +79,9 @@ let test_select () =
 
   let events = Picos_mpscq.create ~padded:true () in
 
-  Bundle.join_after @@ fun bundle ->
+  Flock.join_after @@ fun () ->
   begin
-    Bundle.fork bundle @@ fun () ->
+    Flock.fork @@ fun () ->
     while true do
       match Unix.select [ msg_inn1; msg_inn2 ] [] [] 0.2 with
       | inns, _, _ ->
@@ -111,7 +111,7 @@ let test_select () =
   assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
   assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
 
-  Bundle.terminate bundle;
+  Flock.terminate ();
 
   let expected = [| "Inn1"; "Inn2"; "Timeout" |] in
   let actual =

--- a/test/test_sync.ml
+++ b/test/test_sync.ml
@@ -48,15 +48,15 @@ let test_mutex_and_condition_errors () =
   let mutex = Mutex.create () in
   let condition = Condition.create () in
   Mutex.protect mutex @@ fun () ->
-  Bundle.join_after @@ fun bundle ->
+  Flock.join_after @@ fun () ->
   begin
-    Bundle.fork bundle @@ fun () ->
+    Flock.fork @@ fun () ->
     match Mutex.unlock mutex with
     | () -> assert false
     | exception Sys_error _ -> ()
   end;
   begin
-    Bundle.fork bundle @@ fun () ->
+    Flock.fork @@ fun () ->
     match Condition.wait condition mutex with
     | () -> assert false
     | exception Sys_error _ -> ()


### PR DESCRIPTION
This PR adds to the `picos.structured` library a new `Flock` module, which essentially provides a more convenient interface to the existing `Bundle` mechanism by passing the underlying `Bundle` through `FLS`.

The naming is a bit tongue in cheek.  The idea is that, unlike a "[bundle](https://www.merriam-webster.com/dictionary/bundle)", a "[flock](https://www.merriam-webster.com/dictionary/flock)" (like a flock of birds) is something that you cannot really hold in your hands.   Flock is also a term used in conjuction with fibers.