### PR TITLE
Reduce per fiber allocations in `picos.fifos`

### DIFF
--- a/lib/picos/picos.common.ml
+++ b/lib/picos/picos.common.ml
@@ -29,6 +29,8 @@ module Fiber = struct
   include Picos_ocaml.Fiber
 
   module Maybe = struct
+    let[@inline never] not_a_fiber () = invalid_arg "not a fiber"
+
     type t = T : [< `Nothing | `Fiber ] tdt -> t [@@unboxed]
 
     let[@inline] to_fiber_or_current = function
@@ -57,6 +59,10 @@ module Fiber = struct
     let[@inline] check = function
       | T Nothing -> ()
       | T (Fiber _ as t) -> check t
+
+    let[@inline] to_fiber = function
+      | T Nothing -> not_a_fiber ()
+      | T (Fiber _ as t) -> t
   end
 
   exception Done

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -1000,6 +1000,11 @@ module Fiber : sig
 
         🏎️ This performs no allocations. *)
 
+    val to_fiber : t -> fiber
+    (** [to_fiber] casts the optional fiber to a fiber.
+
+        @raise Invalid_argument in case the optional fiber is {!nothing}. *)
+
     val current_if : bool option -> t
     (** [current_if checked] returns {!nothing} in case [checked] is
         [Some false] and otherwise [of_fiber (Fiber.current ())]. *)

--- a/lib/picos_fifos/picos_fifos.mli
+++ b/lib/picos_fifos/picos_fifos.mli
@@ -22,9 +22,13 @@
     This scheduler also gives priority to fibers woken up from
     {{!Picos.Trigger.await} [await]} due to being canceled. *)
 
-val run : ?forbid:bool -> (unit -> 'a) -> 'a
+val run : ?quota:int -> ?forbid:bool -> (unit -> 'a) -> 'a
 (** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
     and all of the fibers spawned by [main] have returned.
 
     The optional [forbid] argument defaults to [false] and determines whether
-    propagation of cancelation is initially allowed. *)
+    propagation of cancelation is initially allowed.
+
+    The optional [quota] argument defaults to [Int.max_int] and determines the
+    number of effects a fiber is allowed to perform before it is forced to
+    yield. *)


### PR DESCRIPTION
Previously `picos.fifos` used to allocate effect handling functions per fiber.  This PR changes those allocations to be done only once, which reduces per fiber memory usage signficantly.

This also adds an optional `quota` for the number of effects a fiber is allowed to perform before being forced to yield.