### PR TITLE
Optimize `Bundle.fork` to not use per fiber computation

### DIFF
--- a/lib/picos_structured/flock.ml
+++ b/lib/picos_structured/flock.ml
@@ -13,5 +13,5 @@ let terminate_after ?callstack ~seconds () =
 let terminate ?callstack () = Bundle.terminate ?callstack (get ())
 let error ?callstack exn_bt = Bundle.error (get ()) ?callstack exn_bt
 let fork_as_promise thunk = Bundle.fork_as_promise_pass (get ()) thunk FLS
-let fork action = fork_as_promise action |> ignore
+let fork action = Bundle.fork_pass (get ()) action FLS
 let join_after fn = Bundle.join_after_pass fn Bundle.FLS


### PR DESCRIPTION
Per fiber computation is only needed when a fiber is forked as a (separately) cancelable promise.