### PR TITLE
Redesign `Spawn` and introduce concept of fatal errors

### DIFF
--- a/bench/bench_fib.ocaml5.ml
+++ b/bench/bench_fib.ocaml5.ml
@@ -8,8 +8,9 @@ let rec exp_fib i =
   if i < 2 then i
   else
     let computation = Computation.create ~mode:`LIFO () in
-    let main () = Computation.return computation (exp_fib (i - 2)) in
-    Fiber.spawn ~forbid:false computation [ main ];
+    let fiber = Fiber.create ~forbid:false computation in
+    let main _ = Computation.capture computation exp_fib (i - 2) in
+    Fiber.spawn fiber main;
     let f1 = exp_fib (i - 1) in
     let f2 = Computation.await computation in
     f1 + f2

--- a/bench/bench_memory.ml
+++ b/bench/bench_memory.ml
@@ -112,7 +112,7 @@ let run_suite ~budgetf:_ =
         let latch = Latch.create 1 in
         let bytes =
           measure_live_bytes @@ fun () ->
-          let main () =
+          let main _ =
             try
               Latch.incr latch;
               while true do
@@ -121,7 +121,7 @@ let run_suite ~budgetf:_ =
             with Exit -> Latch.decr latch
           in
           for _ = 1 to n do
-            Fiber.spawn ~forbid:false computation [ main ]
+            Fiber.spawn (Fiber.create ~forbid:false computation) main
           done;
           Fiber.yield ()
         in

--- a/bench/bench_spawn.ml
+++ b/bench/bench_spawn.ml
@@ -5,7 +5,7 @@ let factor =
   Util.iter_factor
   * if String.starts_with ~prefix:"4." Sys.ocaml_version then 1 else 10
 
-let run_one ~budgetf ~at_a_time () =
+let run_one ~budgetf () =
   let n_spawns = 10 * factor in
 
   let init _ = () in
@@ -13,25 +13,22 @@ let run_one ~budgetf ~at_a_time () =
   let work _ () =
     let counter = ref n_spawns in
     let computation = Computation.create ~mode:`LIFO () in
-    for _ = 1 to n_spawns / at_a_time do
-      let main () =
-        let n = !counter - 1 in
-        counter := n;
-        if n = 0 then Computation.finish computation
-      in
-      let mains = List.init at_a_time @@ fun _ -> main in
-      Fiber.spawn ~forbid:false computation mains
+    let computation_packed = Computation.Packed computation in
+    let main _ =
+      let n = !counter - 1 in
+      counter := n;
+      if n = 0 then Computation.finish computation
+    in
+    for _ = 1 to n_spawns do
+      let fiber = Fiber.create_packed ~forbid:false computation_packed in
+      Fiber.spawn fiber main
     done;
     Computation.await computation
   in
 
-  let config = Printf.sprintf "%d at a time" at_a_time in
+  let config = "with packed computation" in
   Times.record ~budgetf ~n_domains:1 ~n_warmups:1 ~n_runs_min:1 ~init ~wrap
     ~work ()
   |> Times.to_thruput_metrics ~n:n_spawns ~singular:"spawn" ~config
 
-let run_suite ~budgetf =
-  if Sys.int_size <= 32 then []
-  else
-    [ 1; 2; 4; 8 ]
-    |> List.concat_map @@ fun at_a_time -> run_one ~budgetf ~at_a_time ()
+let run_suite ~budgetf = if Sys.int_size <= 32 then [] else run_one ~budgetf ()

--- a/lib/picos/bootstrap/picos_bootstrap.ml
+++ b/lib/picos/bootstrap/picos_bootstrap.ml
@@ -385,8 +385,7 @@ end
 module Handler = struct
   type 'c t = {
     current : 'c -> Fiber.t;
-    spawn :
-      'a. 'c -> forbid:bool -> 'a Computation.t -> (unit -> unit) list -> unit;
+    spawn : 'c -> Fiber.t -> (Fiber.t -> unit) -> unit;
     yield : 'c -> unit;
     cancel_after :
       'a. 'c -> 'a Computation.t -> seconds:float -> Exn_bt.t -> unit;

--- a/lib/picos/intf.ocaml5.ml
+++ b/lib/picos/intf.ocaml5.ml
@@ -132,13 +132,13 @@ module type Fiber = sig
       associated with the fiber has been canceled the scheduler is free to
       discontinue the fiber immediately before spawning new fibers.
 
-      The scheduler is free to run the newly created fibers on any domain and
+      The scheduler is free to run the newly created fiber on any domain and
       decide which fiber to give priority to.
 
-      ⚠️ The scheduler should guarantee that, when [Spawn] returns normally, all
-      of the [mains] will eventually be called by the scheduler and, when
-      [Spawn] raises an exception, none of the [mains] will be called.  In other
-      words, [Spawn] should check cancelation just once and be all or nothing.
+      ⚠️ The scheduler should guarantee that, when [Spawn] returns normally, the
+      given [main] will eventually be called by the scheduler and, when [Spawn]
+      raises an exception, the [main] will not be called.  In other words,
+      [Spawn] should check cancelation just once and be all or nothing.
       Furthermore, in case a newly spawned fiber is canceled before its main is
       called, the scheduler must still call the main.  This allows a program to
       ensure, i.e. keep track of, that all fibers it spawns are terminated
@@ -146,10 +146,5 @@ module type Fiber = sig
       properly. *)
   type _ Effect.t +=
     private
-    | Spawn : {
-        forbid : bool;
-        computation : 'a computation;
-        mains : (unit -> unit) list;
-      }
-        -> unit Effect.t
+    | Spawn : { fiber : t; main : t -> unit } -> unit Effect.t
 end

--- a/lib/picos_fifos/picos_fifos.mli
+++ b/lib/picos_fifos/picos_fifos.mli
@@ -22,13 +22,29 @@
     This scheduler also gives priority to fibers woken up from
     {{!Picos.Trigger.await} [await]} due to being canceled. *)
 
-val run : ?quota:int -> ?forbid:bool -> (unit -> 'a) -> 'a
-(** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
-    and all of the fibers spawned by [main] have returned.
+open Picos
 
-    The optional [forbid] argument defaults to [false] and determines whether
-    propagation of cancelation is initially allowed.
+val run_fiber :
+  ?quota:int ->
+  ?fatal_exn_handler:(exn -> unit) ->
+  Fiber.t ->
+  (Fiber.t -> unit) ->
+  unit
+(** [run_fiber fiber main] runs the [main] program as the specified [fiber] and
+    returns after [main] and all of the fibers spawned by [main] have returned.
 
     The optional [quota] argument defaults to [Int.max_int] and determines the
     number of effects a fiber is allowed to perform before it is forced to
     yield. *)
+
+val run :
+  ?quota:int ->
+  ?fatal_exn_handler:(exn -> unit) ->
+  ?forbid:bool ->
+  (unit -> 'a) ->
+  'a
+(** [run main] is equivalent to calling {!run_fiber} with a freshly created
+    fiber and [main] wrapped to capture the result of [main].
+
+    The optional [forbid] argument defaults to [false] and determines whether
+    propagation of cancelation is initially allowed. *)

--- a/lib/picos_lwt/picos_lwt.mli
+++ b/lib/picos_lwt/picos_lwt.mli
@@ -7,6 +7,8 @@
     ℹ️ This is a {{!System} system} independent interface to {!Lwt}.  See
     {!Picos_lwt_unix} for a {!Unix} specific interface. *)
 
+open Picos
+
 val await : 'a Lwt.t -> 'a
 (** [await promise] awaits for the [promise] to resolve and returns the result.
 
@@ -15,16 +17,21 @@ val await : 'a Lwt.t -> 'a
 
 include module type of Intf
 
-val run : ?forbid:bool -> (module System) -> (unit -> 'a) -> 'a Lwt.t
-(** [run (module System) main] runs the [main] program implemented in {!Picos}
-    as a promise with {!Lwt} as the scheduler using the given {!System} module.
-    In other words, the [main] program will be run as a {!Lwt} promise or fiber.
+val run_fiber : (module System) -> Fiber.t -> (Fiber.t -> unit) -> unit Lwt.t
+(** [run_fiber (module System) fiber main] runs the [main] program as the
+    specified [fiber] as a promise with {!Lwt} as the scheduler using the given
+    {!System} module.  In other words, the [main] program will be run as a
+    {!Lwt} promise or fiber.
 
     ℹ️ Inside [main] you can use anything implemented in Picos for concurrent
     programming.  In particular, you only need to call [run] with a {!System}
     module implementation at the entry point of your application.
 
-    The optional [forbid] argument defaults to [false] and determines whether
-    propagation of cancelation is initially allowed.
-
     ⚠️ This may only be called on the main thread on which {!Lwt} runs. *)
+
+val run : ?forbid:bool -> (module System) -> (unit -> 'a) -> 'a Lwt.t
+(** [run (module System) main] is equivalent to calling {!run_fiber} with a
+    freshly created fiber and [main] wrapped to capture the result of [main].
+
+    The optional [forbid] argument defaults to [false] and determines whether
+    propagation of cancelation is initially allowed. *)

--- a/lib/picos_lwt_unix/picos_lwt_unix.mli
+++ b/lib/picos_lwt_unix/picos_lwt_unix.mli
@@ -1,9 +1,19 @@
 (** Direct style {!Picos} compatible interface to {!Lwt} with {!Lwt_unix} for
     OCaml 5. *)
 
-val run : ?forbid:bool -> (unit -> 'a) -> 'a Lwt.t
-(** [run main] runs the [main] program implemented in {!Picos} as a promise with
-    {!Lwt} as the scheduler using a {!Lwt_unix} based {{!Picos_lwt.System}
-    [System]} module.
+open Picos
+
+val run_fiber : Fiber.t -> (Fiber.t -> unit) -> unit Lwt.t
+(** [run_fiber fiber main] runs the [main] program as the specified [fiber] as a
+    promise with {!Lwt} as the scheduler using a {!Lwt_unix} based
+    {{!Picos_lwt.System} [System]} module.  In other words, the [main] program
+    will be run as a {!Lwt} promise or fiber.
 
     ⚠️ This may only be called on the main thread on which {!Lwt} runs. *)
+
+val run : ?forbid:bool -> (unit -> 'a) -> 'a Lwt.t
+(** [run main] is equivalent to calling {!run_fiber} with a freshly created
+    fiber and [main] wrapped to capture the result of [main].
+
+    The optional [forbid] argument defaults to [false] and determines whether
+    propagation of cancelation is initially allowed. *)

--- a/lib/picos_randos/picos_randos.mli
+++ b/lib/picos_randos/picos_randos.mli
@@ -10,10 +10,12 @@
     bugs in programs implemented in Picos that make invalid scheduling
     assumptions. *)
 
+open Picos
+
 type t
 (** Represents a shared context for randomized runners. *)
 
-val context : unit -> t
+val context : ?fatal_exn_handler:(exn -> unit) -> unit -> t
 (** [context ()] creates a new context for randomized runners.  The context
     should be consumed by a call of {{!run} [run ~context ...]}. *)
 
@@ -22,21 +24,42 @@ val runner_on_this_thread : t -> unit
     fibers on the context.  The runner returns when {{!run} [run ~context ...]}
     returns. *)
 
-val run : ?context:t -> ?forbid:bool -> (unit -> 'a) -> 'a
-(** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
-    and all of the fibers spawned by [main] have returned.
+val run_fiber : ?context:t -> Fiber.t -> (Fiber.t -> unit) -> unit
+(** [run_fiber fiber main] runs the [main] program as the specified [fiber] and
+    returns [main] and all of the fibers spawned by [main] have returned.
 
     The optional [context] argument specifies a context in which to run the
-    [main] thunk.  If unspecified, a new context is automatically created and
+    [main] program.  If unspecified, a new context is automatically created and
     the scheduler will be single-threaded.  By {{!context} creating a context},
     spawning concurrent or parallel {{!runner_on_this_thread} runners} on to the
     context, and then explicitly passing the context to [run ~context ...] one
     can create a multi-threaded scheduler.  Only a single call of {!run} per
-    context is allowed.
+    context is allowed. *)
+
+val run : ?context:t -> ?forbid:bool -> (unit -> 'a) -> 'a
+(** [run main] is equivalent to calling {!run_fiber} with a freshly created
+    fiber and [main] wrapped to capture the result of [main].
 
     The optional [forbid] argument defaults to [false] and determines whether
     propagation of cancelation is initially allowed. *)
 
-val run_on : n_domains:int -> ?forbid:bool -> (unit -> 'a) -> 'a
-(** [run_on ~n_domains main] spawns [n_domains - 1] additional domains and runs
-    the [main] on the current domain and those additional domains. *)
+val run_fiber_on :
+  ?fatal_exn_handler:(exn -> unit) ->
+  n_domains:int ->
+  Fiber.t ->
+  (Fiber.t -> unit) ->
+  unit
+(** [run_fiber_on ~n_domains main] spawns [n_domains - 1] additional domains and
+    runs the [main] on the current domain and those additional domains. *)
+
+val run_on :
+  ?fatal_exn_handler:(exn -> unit) ->
+  n_domains:int ->
+  ?forbid:bool ->
+  (unit -> 'a) ->
+  'a
+(** [run_on ~n_domains main] is equivalent to calling {!run_fiber_on} with a
+    freshly created fiber and [main] wrapped to capture the result of [main].
+
+    The optional [forbid] argument defaults to [false] and determines whether
+    propagation of cancelation is initially allowed. *)

--- a/lib/picos_structured/run.ml
+++ b/lib/picos_structured/run.ml
@@ -1,32 +1,34 @@
 open Picos
 
-let wrap_all t main =
-  Bundle.unsafe_incr t;
-  fun () ->
-    if Bundle.is_running t then begin
-      try main () with exn -> Bundle.error t (Exn_bt.get exn)
-    end;
-    Bundle.decr t
+let wrap_all t main _ =
+  if Bundle.is_running t then begin
+    try main () with exn -> Bundle.error t (Exn_bt.get exn)
+  end;
+  Bundle.decr t
 
-let wrap_any t main =
-  Bundle.unsafe_incr t;
-  fun () ->
-    if Bundle.is_running t then begin
-      try
-        main ();
-        Bundle.terminate t
-      with exn -> Bundle.error t (Exn_bt.get exn)
-    end;
-    Bundle.decr t
+let wrap_any t main _ =
+  if Bundle.is_running t then begin
+    match main () with
+    | () -> Bundle.terminate t
+    | exception exn -> Bundle.error t (Exn_bt.get exn)
+  end;
+  Bundle.decr t
+
+let rec spawn (Bundle r as t : Bundle.t) wrap = function
+  | [] -> ()
+  | main :: mains ->
+      Bundle.unsafe_incr t;
+      let fiber = Fiber.create_packed ~forbid:false r.bundle in
+      Fiber.spawn fiber (wrap t main);
+      spawn t wrap mains
 
 let run actions wrap =
-  Bundle.join_after @@ fun (Bundle r as t : Bundle.t) ->
-  try
-    let mains = List.map (wrap t) actions in
-    Fiber.spawn ~forbid:false r.bundle mains
+  Bundle.join_after @@ fun (Bundle _ as t : Bundle.t) ->
+  try spawn t wrap actions
   with exn ->
-    Bundle.unsafe_reset t;
-    raise exn
+    let exn_bt = Exn_bt.get exn in
+    Bundle.decr t;
+    Bundle.error t exn_bt
 
 let all actions = run actions wrap_all
 let any actions = run actions wrap_any

--- a/lib/picos_threaded/picos_threaded.mli
+++ b/lib/picos_threaded/picos_threaded.mli
@@ -24,9 +24,16 @@
     OCaml 5 a scheduler that implements an effect handler directly is likely to
     perform better. *)
 
-val run : ?forbid:bool -> (unit -> 'a) -> 'a
-(** [run main] runs the [main] thunk with the scheduler.  Returns after [main]
-    and all of the fibers spawned by [main] have returned.
+open Picos
+
+val run_fiber :
+  ?fatal_exn_handler:(exn -> unit) -> Fiber.t -> (Fiber.t -> unit) -> unit
+(** [run_fiber fiber main] runs the [main] program as the specified [fiber] and
+    returns [main] and all of the fibers spawned by [main] have returned. *)
+
+val run : ?forbid:bool -> ?fatal_exn_handler:(exn -> unit) -> (unit -> 'a) -> 'a
+(** [run main] is equivalent to calling {!run_fiber} with a freshly created
+    fiber and [main] wrapped to capture the result of [main].
 
     The optional [forbid] argument defaults to [false] and determines whether
     propagation of cancelation is initially allowed. *)

--- a/test/test_scheduler.ocaml5.ml
+++ b/test/test_scheduler.ocaml5.ml
@@ -1,6 +1,8 @@
 let () = Printexc.record_backtrace true
 let () = Random.self_init ()
 
+open Picos
+
 let () =
   Picos_select.check_configured ();
 
@@ -15,18 +17,44 @@ let () =
   in
   propagate ()
 
-let rec run ?(max_domains = 1) ?(allow_lwt = true) ?forbid main =
+let rec run_fiber ?(max_domains = 1) ?(allow_lwt = true) ?fatal_exn_handler
+    fiber main =
   let scheduler =
     match Random.int 3 with 0 -> `Fifos | 1 -> `Randos | _ -> `Lwt
   in
+  ignore
+    (match scheduler with
+    | `Fifos -> "fifos"
+    | `Randos -> "randos"
+    | `Lwt -> "lwt");
   match scheduler with
   | `Lwt ->
-      if Picos_thread.is_main_thread () && allow_lwt then
-        Lwt_main.run (Picos_lwt_unix.run ?forbid main)
-      else run ~max_domains ~allow_lwt ?forbid main
+      if Picos_thread.is_main_thread () && allow_lwt then begin
+        let old_hook = !Lwt.async_exception_hook in
+        begin
+          match fatal_exn_handler with
+          | None -> ()
+          | Some hook -> Lwt.async_exception_hook := hook
+        end;
+        match Lwt_main.run (Picos_lwt_unix.run_fiber fiber main) with
+        | result ->
+            Lwt.async_exception_hook := old_hook;
+            result
+        | exception exn ->
+            Lwt.async_exception_hook := old_hook;
+            raise exn
+      end
+      else run_fiber ~max_domains ~allow_lwt fiber main
   | `Randos ->
       let n_domains =
         Int.min max_domains (Domain.recommended_domain_count ())
       in
-      Picos_randos.run_on ~n_domains ?forbid main
-  | `Fifos -> Picos_fifos.run ?forbid main
+      Picos_randos.run_fiber_on ?fatal_exn_handler ~n_domains fiber main
+  | `Fifos -> Picos_fifos.run_fiber ?fatal_exn_handler fiber main
+
+let run ?max_domains ?allow_lwt ?fatal_exn_handler ?(forbid = false) main =
+  let computation = Computation.create ~mode:`LIFO () in
+  let fiber = Fiber.create ~forbid computation in
+  let main _ = Computation.capture computation main () in
+  run_fiber ?max_domains ?allow_lwt ?fatal_exn_handler fiber main;
+  Computation.await computation

--- a/test/test_structured.ml
+++ b/test/test_structured.ml
@@ -108,13 +108,13 @@ let test_block_raises_sys_error () =
   let success = ref false in
   let finished = Trigger.create () in
   let computation = Computation.create () in
-  let main () =
+  let main _ =
     begin
       try Control.block () with Sys_error _ -> success := true
     end;
     Trigger.signal finished
   in
-  Fiber.spawn ~forbid:false computation [ main ];
+  Fiber.spawn (Fiber.create ~forbid:false computation) main;
   Control.sleep ~seconds:0.1;
   Computation.finish computation;
   Trigger.await finished |> ignore;


### PR DESCRIPTION
This PR essentially redesigns the `Fiber.spawn` mechanism to allow `FLS` to be populated before a fiber is spawned. Being able to populate the `FLS` before spawn can be used to reduce the amount of allocations required (i.e. this results in smaller `main` closure for the fiber) and also allows some use cases to be implemented more easily.

This also removes the early idea of giving a list of `main` functions, which allowed multiple fibers to be spawned with a single effect.  It seems that moving the allocation of the fiber record to happen before `spawn` also speeds up a single spawn.  This is nice, because, in most cases, one spawns one fiber at a time.

This also introduces the concept of _fatal errors_.  Previously, if the `main` function of a fiber raised an exception, it was considered to be undefined behavior.  This is a subtle way to say that `main` had to always handle all exceptions, because raising an exception had no behavior that one could rely upon.  This is now changed such that raising an exception from the `main` function is considered a _fatal error_, which is guaranteed to stop the entire program.

On the other hand, these changes move the requirement that fiber records are unique to be maintained outside of the scheduler.