### PR TITLE
Fix to actually update the quota

### DIFF
--- a/bench/scheduler.ocaml5.ml
+++ b/bench/scheduler.ocaml5.ml
@@ -1,1 +1,1 @@
-let run main = Picos_fifos.run main
+let run main = Picos_fifos.run ~quota:100 main


### PR DESCRIPTION
This fixes `Picos_fifos` to actually update the remaining `quota` after performing an effect successfully and also changes the benchmark scheduler to specify `~quota:100`.