### PR TITLE
Use TLS to store current fiber in `picos.randos`

### DIFF
--- a/lib/picos_randos/dune
+++ b/lib/picos_randos/dune
@@ -11,4 +11,5 @@
    (picos.select -> select.some.ml)
    (-> select.none.ml))
   multicore-magic
+  picos.thread
   picos.htbl))


### PR DESCRIPTION
This allows the effect handlers to be preallocated once and the space taken by a fiber reduced significantly.