### PR TITLE
Add multi-producer multi-consumer queue allowing pushes to both ends

### DIFF
--- a/bench/bench_binaries.ml
+++ b/bench/bench_binaries.ml
@@ -21,6 +21,7 @@ let paths =
     lib "picos_htbl";
     lib "picos_lwt";
     lib "picos_lwt_unix";
+    lib "picos_mpmcq";
     lib "picos_mpscq";
     lib "picos_randos";
     lib "picos_rc";

--- a/lib/index.mld
+++ b/lib/index.mld
@@ -191,6 +191,7 @@ implementation of the other libraries.
   Picos_exn_bt
   Picos_fd
   Picos_htbl
+  Picos_mpmcq
   Picos_mpscq
   Picos_rc
   Picos_thread

--- a/lib/picos_mpmcq/dune
+++ b/lib/picos_mpmcq/dune
@@ -1,0 +1,8 @@
+(library
+ (name picos_mpmcq)
+ (public_name picos.mpmcq)
+ (libraries backoff multicore-magic))
+
+(mdx
+ (libraries picos.mpmcq)
+ (files picos_mpmcq.mli))

--- a/lib/picos_mpmcq/picos_mpmcq.ml
+++ b/lib/picos_mpmcq/picos_mpmcq.ml
@@ -1,0 +1,186 @@
+module Atomic = Multicore_magic.Transparent_atomic
+
+type 'a t = { head : 'a head Atomic.t; tail : 'a tail Atomic.t }
+
+and ('a, _) tdt =
+  | Cons : {
+      counter : int;
+      value : 'a;
+      suffix : 'a head;
+    }
+      -> ('a, [> `Cons ]) tdt
+  | Head : { counter : int } -> ('a, [> `Head ]) tdt
+  | Snoc : {
+      counter : int;
+      prefix : 'a tail;
+      value : 'a;
+    }
+      -> ('a, [> `Snoc ]) tdt
+  | Tail : {
+      counter : int;
+      mutable move : ('a, [ `Snoc | `Used ]) tdt;
+    }
+      -> ('a, [> `Tail ]) tdt
+  | Used : ('a, [> `Used ]) tdt
+
+and 'a head = H : ('a, [< `Cons | `Head ]) tdt -> 'a head [@@unboxed]
+and 'a tail = T : ('a, [< `Snoc | `Tail ]) tdt -> 'a tail [@@unboxed]
+
+let create ?padded () =
+  let head =
+    Atomic.make (H (Head { counter = 1 })) |> Multicore_magic.copy_as ?padded
+  in
+  let tail =
+    Atomic.make (T (Tail { counter = 0; move = Obj.magic () }))
+    |> Multicore_magic.copy_as ?padded
+  in
+  Multicore_magic.copy_as ?padded { head; tail }
+
+let rec rev (suffix : (_, [< `Cons ]) tdt) = function
+  | T (Snoc { counter; prefix; value }) ->
+      rev (Cons { counter; value; suffix = H suffix }) prefix
+  | T (Tail _) -> suffix
+
+let rev = function
+  | (Snoc { counter; prefix; value } : (_, [< `Snoc ]) tdt) ->
+      rev
+        (Cons { counter; value; suffix = H (Head { counter = counter + 1 }) })
+        prefix
+
+let rec push t value backoff = function
+  | T (Snoc snoc_r as snoc) -> push_with t value backoff snoc_r.counter (T snoc)
+  | T (Tail tail_r as tail) -> begin
+      match tail_r.move with
+      | Used -> push_with t value backoff tail_r.counter (T tail)
+      | Snoc move_r as move ->
+          begin
+            match Atomic.get t.head with
+            | H (Head head_r as head) when head_r.counter < move_r.counter ->
+                let after = rev move in
+                if
+                  Atomic.fenceless_get t.head == H head
+                  && Atomic.compare_and_set t.head (H head) (H after)
+                then tail_r.move <- Used
+            | _ -> ()
+          end;
+          let new_tail = Atomic.fenceless_get t.tail in
+          if new_tail != T tail then push t value backoff new_tail
+          else push_with t value backoff tail_r.counter (T tail)
+    end
+
+and push_with t value backoff counter prefix =
+  let after = Snoc { counter = counter + 1; prefix; value } in
+  let new_tail = Atomic.fenceless_get t.tail in
+  if new_tail != prefix then push t value backoff new_tail
+  else if not (Atomic.compare_and_set t.tail prefix (T after)) then
+    let backoff = Backoff.once backoff in
+    push t value backoff (Atomic.fenceless_get t.tail)
+
+let push t value = push t value Backoff.default (Atomic.fenceless_get t.tail)
+
+let rec push_head t value backoff =
+  match Atomic.get t.head with
+  | H (Cons cons_r) as suffix ->
+      let after = Cons { counter = cons_r.counter - 1; value; suffix } in
+      if not (Atomic.compare_and_set t.head suffix (H after)) then
+        push_head t value (Backoff.once backoff)
+  | H (Head head_r) as head -> begin
+      match Atomic.get t.tail with
+      | T (Snoc snoc_r as move) ->
+          if Atomic.get t.head != head then push_head t value backoff
+          else if head_r.counter = snoc_r.counter then begin
+            let prefix = T (Snoc { snoc_r with value }) in
+            let after =
+              Snoc { snoc_r with counter = snoc_r.counter + 1; prefix }
+            in
+            if not (Atomic.compare_and_set t.tail (T move) (T after)) then
+              push_head t value (Backoff.once backoff)
+          end
+          else
+            let tail = Tail { counter = snoc_r.counter; move } in
+            let backoff =
+              if Atomic.compare_and_set t.tail (T move) (T tail) then backoff
+              else Backoff.once backoff
+            in
+            push_head t value backoff
+      | T (Tail tail_r) as prefix -> begin
+          match tail_r.move with
+          | Used ->
+              if Atomic.get t.head == head then begin
+                let tail =
+                  Snoc { counter = tail_r.counter + 1; value; prefix }
+                in
+                if not (Atomic.compare_and_set t.tail prefix (T tail)) then
+                  push_head t value (Backoff.once backoff)
+              end
+              else push_head t value backoff
+          | Snoc move_r as move ->
+              begin
+                match Atomic.get t.head with
+                | H (Head head_r as head) when head_r.counter < move_r.counter
+                  ->
+                    let after = rev move in
+                    if
+                      Atomic.fenceless_get t.head == H head
+                      && Atomic.compare_and_set t.head (H head) (H after)
+                    then tail_r.move <- Used
+                | _ -> ()
+              end;
+              push_head t value backoff
+        end
+    end
+
+let push_head t value = push_head t value Backoff.default
+
+exception Empty
+
+let rec pop t backoff = function
+  | H (Cons cons_r as cons) ->
+      if Atomic.compare_and_set t.head (H cons) cons_r.suffix then cons_r.value
+      else
+        let backoff = Backoff.once backoff in
+        pop t backoff (Atomic.fenceless_get t.head)
+  | H (Head head_r as head) -> begin
+      match Atomic.fenceless_get t.tail with
+      | T (Snoc snoc_r as move) ->
+          if head_r.counter = snoc_r.counter then
+            if Atomic.compare_and_set t.tail (T move) snoc_r.prefix then
+              snoc_r.value
+            else pop t backoff (Atomic.fenceless_get t.head)
+          else
+            let tail = Tail { counter = snoc_r.counter; move } in
+            let new_head = Atomic.get t.head in
+            if new_head != H head then pop t backoff new_head
+            else if Atomic.compare_and_set t.tail (T move) (T tail) then
+              pop_moving t backoff head move tail
+            else pop t backoff (Atomic.fenceless_get t.head)
+      | T (Tail tail_r as tail) -> begin
+          match tail_r.move with
+          | Used -> pop_emptyish t backoff head
+          | Snoc _ as move -> pop_moving t backoff head move tail
+        end
+    end
+
+and pop_moving t backoff (Head head_r as head : (_, [ `Head ]) tdt)
+    (Snoc move_r as move : (_, [ `Snoc ]) tdt)
+    (Tail tail_r : (_, [ `Tail ]) tdt) =
+  if head_r.counter < move_r.counter then
+    match rev move with
+    | Cons cons_r ->
+        let after = cons_r.suffix in
+        let new_head = Atomic.get t.head in
+        if new_head != H head then pop t backoff new_head
+        else if Atomic.compare_and_set t.head (H head) after then begin
+          tail_r.move <- Used;
+          cons_r.value
+        end
+        else
+          let backoff = Backoff.once backoff in
+          pop t backoff (Atomic.fenceless_get t.head)
+  else pop_emptyish t backoff head
+
+and pop_emptyish t backoff head =
+  let new_head = Atomic.get t.head in
+  if new_head == H head then raise_notrace Empty else pop t backoff new_head
+
+let pop_exn t = pop t Backoff.default (Atomic.fenceless_get t.head)

--- a/lib/picos_mpmcq/picos_mpmcq.mli
+++ b/lib/picos_mpmcq/picos_mpmcq.mli
@@ -1,0 +1,57 @@
+(** Lock-free multi-producer, multi-consumer queue.
+
+    🏎️ This data structure is optimized for use as the ready queue of a fair
+    (i.e. FIFO) multi-threaded scheduler. *)
+
+(** {1 API} *)
+
+type !'a t
+(** A multi-producer, multi-consumer queue. *)
+
+val create : ?padded:bool -> unit -> 'a t
+(** [create ()] returns a new empty multi-producer, multi-consumer queue. *)
+
+val push : 'a t -> 'a -> unit
+(** [push queue value] adds the [value] to the tail of the [queue]. *)
+
+val push_head : 'a t -> 'a -> unit
+(** [push_head queue value] adds the [value] to the head of the [queue]. *)
+
+exception Empty
+(** Raised by {!pop_exn} in case it finds the queue empty. *)
+
+val pop_exn : 'a t -> 'a
+(** [pop_exn queue] tries to remove the value at the head of the [queue].
+    Returns the removed value or raises {!Empty} in case the queue was empty.
+
+    @raise Empty in case the queue was empty. *)
+
+(** {1 Examples}
+
+    An example top-level session:
+    {[
+      # let q : int Picos_mpmcq.t =
+          Picos_mpmcq.create ()
+      val q : int Picos_mpmcq.t = <abstr>
+
+      # Picos_mpmcq.push q 42
+      - : unit = ()
+
+      # Picos_mpmcq.push_head q 76
+      - : unit = ()
+
+      # Picos_mpmcq.push q 101
+      - : unit = ()
+
+      # Picos_mpmcq.pop_exn q
+      - : int = 76
+
+      # Picos_mpmcq.pop_exn q
+      - : int = 42
+
+      # Picos_mpmcq.pop_exn q
+      - : int = 101
+
+      # Picos_mpmcq.pop_exn q
+      Exception: Picos_mpmcq.Empty.
+    ]} *)

--- a/lib/picos_mpscq/picos_mpscq.mli
+++ b/lib/picos_mpscq/picos_mpscq.mli
@@ -1,7 +1,7 @@
 (** Lock-free multi-producer, single-consumer queue.
 
-    🏎️ This data structure is optimized for use as a non-work-stealing
-    scheduler's ready queue. *)
+    🏎️ This data structure is optimized for use as the ready queue of a fair
+    (i.e. FIFO) single-threaded scheduler. *)
 
 (** {1 API} *)
 

--- a/test/dune
+++ b/test/dune
@@ -133,6 +133,16 @@
   stm_run))
 
 (test
+ (name test_mpmcq)
+ (modules test_mpmcq)
+ (libraries
+  picos.mpmcq
+  qcheck-core
+  qcheck-multicoretests-util
+  qcheck-stm.stm
+  stm_run))
+
+(test
  (name test_htbl)
  (modules test_htbl)
  (libraries

--- a/test/test_mpmcq.ml
+++ b/test/test_mpmcq.ml
@@ -1,0 +1,76 @@
+open QCheck
+open STM
+module Queue = Picos_mpmcq
+
+let () =
+  let q = Queue.create () in
+  Queue.push q 101;
+  Queue.push q 42;
+  assert (Queue.pop_exn q = 101);
+  Queue.push q 76;
+  assert (Queue.pop_exn q = 42);
+  assert (Queue.pop_exn q = 76);
+  match Queue.pop_exn q with _ -> assert false | exception Queue.Empty -> ()
+
+module Spec = struct
+  type cmd = Push of int | Push_head of int | Pop_opt
+
+  let show_cmd = function
+    | Push x -> "Push " ^ string_of_int x
+    | Push_head x -> "Push_head " ^ string_of_int x
+    | Pop_opt -> "Pop_opt"
+
+  module State = struct
+    type t = int list * int list
+
+    let push x (h, t) = if h == [] then ([ x ], []) else (h, x :: t)
+    let push_head x (h, t) = (x :: h, t)
+    let peek_opt (h, _) = match h with x :: _ -> Some x | [] -> None
+
+    let drop ((h, t) as s) =
+      match h with [] -> s | [ _ ] -> (List.rev t, []) | _ :: h -> (h, t)
+  end
+
+  type state = State.t
+  type sut = int Queue.t
+
+  let arb_cmd _s =
+    [
+      Gen.int_range 1 1000 |> Gen.map (fun x -> Push x);
+      Gen.int_range 1 1000 |> Gen.map (fun x -> Push_head x);
+      Gen.return Pop_opt;
+    ]
+    |> Gen.oneof |> make ~print:show_cmd
+
+  let init_state = ([], [])
+  let init_sut () = Queue.create ~padded:true ()
+  let cleanup _ = ()
+
+  let next_state c s =
+    match c with
+    | Push x -> State.push x s
+    | Push_head x -> State.push_head x s
+    | Pop_opt -> State.drop s
+
+  let precond _ _ = true
+
+  let run c d =
+    match c with
+    | Push x -> Res (unit, Queue.push d x)
+    | Push_head x -> Res (unit, Queue.push_head d x)
+    | Pop_opt ->
+        Res
+          ( option int,
+            match Queue.pop_exn d with
+            | v -> Some v
+            | exception Queue.Empty -> None )
+
+  let postcond c (s : state) res =
+    match (c, res) with
+    | Push _x, Res ((Unit, _), ()) -> true
+    | Push_head _x, Res ((Unit, _), ()) -> true
+    | Pop_opt, Res ((Option Int, _), res) -> res = State.peek_opt s
+    | _, _ -> false
+end
+
+let () = Stm_run.run ~name:"Picos_mpmcq" (module Spec) |> exit


### PR DESCRIPTION
This adds a MPMC queue with the ability to push to both ends of the queue, which makes it possible to prioritize cancelation.

This should already give pretty good performance when mostly used from one domain.

The `push_head` operation can be optimized further (I did a quick attempt and got up to 15% improvement in a high contention benchmark) and there are probably some more tweaks that could improve performance a bit, but I'm leaving that to future work.