### PR TITLE
Add minimalist Cohttp implementation using `Picos_stdio`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ scheduler agnostic libraries (e.g.
 [`picos.structured`](https://ocaml-multicore.github.io/picos/doc/picos/Picos_structured/index.html),
 [`picos.sync`](https://ocaml-multicore.github.io/picos/doc/picos/Picos_sync/index.html),
 [`picos.stdio`](https://ocaml-multicore.github.io/picos/doc/picos/Picos_stdio/index.html),
+[`picos.stdio.cohttp`](https://ocaml-multicore.github.io/picos/doc/picos/Picos_stdio_cohttp/index.html),
 and
 [`picos.select`](https://ocaml-multicore.github.io/picos/doc/picos/Picos_select/index.html)),
 or auxiliary libraries.

--- a/dune-project
+++ b/dune-project
@@ -40,6 +40,13 @@
   ;; For picos.lwt
   (lwt
    (>= 5.7.0))
+  ;; For picos.stdio.cohttp
+  (cohttp
+   (>= 6.0.0~beta2))
+  (uri
+   (>= 4.4.0))
+  (fmt
+   (>= 0.9.0))
   ;; Test dependencies
   (multicore-bench
    (and
@@ -99,10 +106,6 @@
   (ocaml
    (>= 4.14.0)))
  (depopts
-  (cohttp
-   (and
-    (>= 5.3.1)
-    :with-test))
   (cohttp-lwt
    (and
     (>= 5.3.0)
@@ -114,8 +117,4 @@
   (conduit-lwt-unix
    (and
     (>= 6.2.2)
-    :with-test))
-  (uri
-   (and
-    (>= 4.4.0)
     :with-test))))

--- a/lib/index.mld
+++ b/lib/index.mld
@@ -167,6 +167,7 @@ These are examples of libraries implemented in Picos.
   Picos_structured
   Picos_sync
   Picos_stdio
+  Picos_stdio_cohttp
   Picos_select
 }
 

--- a/lib/picos_select/picos_select.mli
+++ b/lib/picos_select/picos_select.mli
@@ -99,7 +99,8 @@ val on_sigchld : unit Event.t
 
 (** {2 Configuration} *)
 
-val configure : ?intr_sig:int -> ?handle_sigchld:bool -> unit -> unit
+val configure :
+  ?intr_sig:int -> ?handle_sigchld:bool -> ?ignore_sigpipe:bool -> unit -> unit
 (** [configure ~intr_sig ~handle_sigchld ()] can, and sometimes must, be called
     by an application to configure the use of signals by this module.
 
@@ -110,6 +111,10 @@ val configure : ?intr_sig:int -> ?handle_sigchld:bool -> unit -> unit
     module should setup handling of {!Sys.sigchld}.  The default is [true].
     When explicitly specified as [~handle_sigchld:false], the application should
     arrange to call {!handle_signal} whenever a {!Sys.sigchld} signal occurs.
+
+    The optional [ignore_sigpipe] argument can be used to specify whether
+    {!Sys.sigpipe} will be configured to be ignored or not.  The default is
+    [true].
 
     ⚠️ This module must always be configured before use.  Unless this module has
     been explicitly configured, calling a method of this module from the main

--- a/lib/picos_stdio_cohttp/dune
+++ b/lib/picos_stdio_cohttp/dune
@@ -1,0 +1,10 @@
+(library
+ (name picos_stdio_cohttp)
+ (public_name picos.stdio.cohttp)
+ (libraries
+  (re_export picos.stdio)
+  (re_export cohttp)
+  (re_export uri)
+  fmt
+  picos.finally
+  picos.structured))

--- a/lib/picos_stdio_cohttp/picos_stdio_cohttp.ml
+++ b/lib/picos_stdio_cohttp/picos_stdio_cohttp.ml
@@ -1,0 +1,322 @@
+open Picos_finally
+open Picos_stdio
+open Picos_structured
+
+(* *)
+
+module Private = struct
+  module IO = struct
+    let[@inline never] locked () = invalid_arg "locked"
+
+    type 'a t = 'a
+
+    let ( >>= ) v f = f v
+    let return v = v
+
+    type conn = Unix.file_descr
+
+    type ic = {
+      mutable bytes : Bytes.t;
+      mutable start : int;
+      mutable stop : int;
+      mutable locked : int;
+      file_descr : Unix.file_descr;
+    }
+
+    let min_buffer = 4096
+
+    let ic file_descr =
+      let bytes = Bytes.create min_buffer in
+      { bytes; start = 0; stop = 0; locked = 0; file_descr }
+
+    let rec refill ic =
+      if
+        min_buffer < Bytes.length ic.bytes
+        && (ic.stop - ic.start) * 4 < Bytes.length ic.bytes
+      then begin
+        let bytes = Bytes.create (Bytes.length ic.bytes lsr 1) in
+        Bytes.blit ic.bytes ic.start bytes 0 (ic.stop - ic.start);
+        ic.bytes <- bytes;
+        ic.stop <- ic.stop - ic.start;
+        ic.start <- 0
+      end;
+      if ic.stop < Bytes.length ic.bytes then begin
+        let n =
+          Unix.read ic.file_descr ic.bytes ic.stop
+            (Bytes.length ic.bytes - ic.stop)
+        in
+        if 0 < n then begin
+          ic.stop <- ic.stop + n;
+          `Ok
+        end
+        else `Eof
+      end
+      else if 0 < ic.start then begin
+        if 0 < ic.locked then locked ();
+        let stop = ic.stop - ic.start in
+        Bytes.blit ic.bytes ic.start ic.bytes 0 stop;
+        ic.start <- 0;
+        ic.stop <- stop;
+        refill ic
+      end
+      else begin
+        let bytes = Bytes.create (Bytes.length ic.bytes * 2) in
+        Bytes.blit ic.bytes 0 bytes 0 ic.stop;
+        ic.bytes <- bytes;
+        refill ic
+      end
+
+    let with_input_buffer ic ~f =
+      let string = Bytes.unsafe_to_string ic.bytes in
+      ic.locked <- ic.locked + 1;
+      match f string ~pos:ic.start ~len:(ic.stop - ic.start) with
+      | result, n ->
+          ic.locked <- ic.locked - 1;
+          ic.start <- ic.start + n;
+          result
+      | exception exn ->
+          ic.locked <- ic.locked - 1;
+          raise exn
+
+    let read_line_finish ic i =
+      if i = 0 && ic.start = ic.stop then None
+      else
+        let n =
+          i - Bool.to_int (0 < i && Bytes.get ic.bytes (ic.start + i - 1) = '\r')
+        in
+        let result = Some (Bytes.sub_string ic.bytes ic.start n) in
+        ic.start <- ic.start + i + Bool.to_int (ic.start + i < ic.stop - 1);
+        result
+
+    let rec read_line_to_lf ic i =
+      if ic.start + i < ic.stop then
+        if Bytes.get ic.bytes (ic.start + i) <> '\n' then
+          read_line_to_lf ic (i + 1)
+        else read_line_finish ic i
+      else
+        match refill ic with
+        | `Ok -> read_line_to_lf ic i
+        | `Eof -> read_line_finish ic i
+
+    let read_line ic = read_line_to_lf ic 0
+
+    let rec read ic max_chars =
+      let available = ic.stop - ic.start in
+      if 0 < available then begin
+        let n = Int.min available max_chars in
+        let result = Bytes.sub_string ic.bytes ic.start n in
+        ic.start <- ic.start + n;
+        result
+      end
+      else match refill ic with `Ok -> read ic max_chars | `Eof -> ""
+
+    type oc = Unix.file_descr
+
+    let write oc string =
+      let n = Unix.write_substring oc string 0 (String.length string) in
+      assert (n = String.length string)
+
+    let flush = Unix.fsync
+  end
+end
+
+module Request = Cohttp.Request.Private.Make (Private.IO)
+module Response = Cohttp.Response.Private.Make (Private.IO)
+
+module Body = struct
+  let rec read_with reader read_body_chunk body =
+    match read_body_chunk reader with
+    | Cohttp.Transfer.Done -> raise End_of_file
+    | Chunk data ->
+        Buffer.add_string body data;
+        read_with reader read_body_chunk body
+    | Final_chunk data ->
+        Buffer.add_string body data;
+        `String (Buffer.contents body)
+
+  let read_with has_body make_body_reader read_body_chunk source input =
+    match has_body source with
+    | `No | `Unknown -> `Empty
+    | `Yes ->
+        let body = Buffer.create 4096 in
+        let reader = make_body_reader source input in
+        read_with reader read_body_chunk body
+
+  let write_with write_body = function
+    | `Empty -> ignore
+    | `String body -> fun writer -> write_body writer body
+    | `Strings bodies -> fun writer -> List.iter (write_body writer) bodies
+end
+
+module Client =
+  Cohttp.Generic.Client.Make
+    (struct
+      type 'a io = 'a
+      type body = Cohttp.Body.t
+      type 'a with_context = 'a
+
+      let map_context with_context fn = fn with_context
+
+      let resolve uri =
+        match Uri.scheme uri with
+        | Some "http" -> begin
+            let host = Uri.host_with_default ~default:"localhost" uri in
+            let service =
+              match Uri.port uri with
+              | Some port -> Int.to_string port
+              | None -> Uri.scheme uri |> Option.value ~default:"http"
+            in
+            try
+              Unix.getaddrinfo host service []
+              |> List.find @@ fun ai -> ai.Unix.ai_socktype == SOCK_STREAM
+            with Not_found -> failwith "failed to resolve hostname"
+          end
+        | x ->
+            Fmt.failwith "Unknown scheme %a"
+              Fmt.(option ~none:(any "None") Dump.string)
+              x
+
+      let connect uri =
+        let ai = resolve uri in
+        let socket = Unix.socket ~cloexec:true ai.ai_family ai.ai_socktype 0 in
+        match
+          Unix.set_nonblock socket;
+          Unix.connect socket ai.ai_addr
+        with
+        | () -> socket
+        | exception exn ->
+            Unix.close socket;
+            raise exn
+
+      let call ?headers ?body ?(chunked = false) meth uri =
+        let@ socket = finally Unix.close @@ fun () -> connect uri in
+        let body_length =
+          if chunked then None
+          else
+            match body with
+            | None -> Some 0L
+            | Some body -> Some (Cohttp.Body.length body)
+        in
+        let request =
+          Cohttp.Request.make_for_client ?headers
+            ~chunked:(Option.is_none body_length)
+            ?body_length meth uri
+        in
+        Bundle.join_after @@ fun bundle ->
+        begin
+          Bundle.fork bundle @@ fun () ->
+          Request.write ~flush:false
+            (match body with
+            | None -> ignore
+            | Some body -> Body.write_with Request.write_body body)
+            request socket
+        end;
+        let input = Private.IO.ic socket in
+        match Response.read input with
+        | `Eof -> failwith "connection closed by peer"
+        | `Invalid reason -> failwith reason
+        | `Ok response ->
+            let body =
+              Body.read_with Cohttp.Response.has_body Response.make_body_reader
+                Response.read_body_chunk response input
+            in
+            (response, body)
+    end)
+    (Private.IO)
+
+module Server = struct
+  module IO = Private.IO
+
+  type body = Cohttp.Body.t
+  type conn = IO.conn * Cohttp.Connection.t [@@warning "-3"]
+  type response = Http.Response.t * body
+
+  type response_action =
+    [ `Expert of Http.Response.t * (IO.ic -> IO.oc -> unit IO.t)
+    | `Response of response ]
+
+  type t = {
+    callback : conn -> Http.Request.t -> body -> response_action IO.t;
+    conn_closed : conn -> unit;
+  }
+
+  let make_response_action ?(conn_closed = ignore) ~callback () =
+    { callback; conn_closed }
+
+  let make_expert ?conn_closed ~callback () =
+    let callback conn req body = `Expert (callback conn req body) in
+    make_response_action ?conn_closed ~callback ()
+
+  let make ?conn_closed ~callback () =
+    let callback conn req body = `Response (callback conn req body) in
+    make_response_action ?conn_closed ~callback ()
+
+  let respond ?headers ?flush ~status ~body () =
+    let encoding =
+      match headers with
+      | None -> Cohttp.Body.transfer_encoding body
+      | Some headers -> (
+          match Cohttp.Header.get_transfer_encoding headers with
+          | Http.Transfer.Unknown -> Cohttp.Body.transfer_encoding body
+          | t -> t)
+    in
+    let res = Cohttp.Response.make ~status ?flush ~encoding ?headers () in
+    (res, body)
+
+  let respond_string ?headers ?flush ~status ~body () =
+    let res =
+      Cohttp.Response.make ~status ?flush
+        ~encoding:(Http.Transfer.Fixed (Int64.of_int (String.length body)))
+        ?headers ()
+    in
+    (res, `String body)
+
+  let rec handle t conn ic oc =
+    match Request.read ic with
+    | `Eof -> t.conn_closed conn
+    | `Invalid _data -> t.conn_closed conn
+    | `Ok req -> begin
+        let body =
+          Body.read_with Http.Request.has_body Request.make_body_reader
+            Request.read_body_chunk req ic
+        in
+        match t.callback conn req body with
+        | `Expert (res, io_handler) ->
+            Response.write_header res oc;
+            io_handler ic oc;
+            handle t conn ic oc
+        | `Response (res, body) ->
+            let keep_alive =
+              Http.Request.is_keep_alive req && Http.Response.is_keep_alive res
+            in
+            let headers =
+              Http.Header.add_unless_exists
+                (Http.Response.headers res)
+                "connection"
+                (if keep_alive then "keep-alive" else "close")
+            in
+            let res = { res with headers } in
+            Response.write (Body.write_with Response.write_body body) res oc;
+            if keep_alive then handle t conn ic oc
+      end
+
+  let callback t io ic oc =
+    let id = (Cohttp.Connection.create () [@ocaml.warning "-3"]) in
+    let conn = (io, id) in
+    try handle t conn ic oc
+    with Unix.Unix_error (ECONNRESET, _, _) | Unix.Unix_error (EPIPE, _, _) ->
+      t.conn_closed conn
+
+  let run t server_socket =
+    Bundle.join_after @@ fun bundle ->
+    let rec accept () =
+      let@ client_socket =
+        finally Unix.close @@ fun () ->
+        Unix.accept ~cloexec:true server_socket |> fst
+      in
+      Bundle.fork bundle accept;
+      Unix.set_nonblock client_socket;
+      callback t client_socket (Private.IO.ic client_socket) client_socket
+    in
+    accept ()
+end

--- a/lib/picos_stdio_cohttp/picos_stdio_cohttp.mli
+++ b/lib/picos_stdio_cohttp/picos_stdio_cohttp.mli
@@ -1,0 +1,34 @@
+(** Minimalistic Cohttp implementation using {!Picos_stdio} for {!Picos}.
+
+    ⚠️ This library is currently minimalistic and experimental and is highly
+    likely to change.  Feedback from potential users is welcome! *)
+
+open Picos_stdio
+
+(** Convenience funtions for constructing and processing requests.
+
+    Please consult the
+    {{:https://ocaml.org/p/cohttp/latest/doc/Cohttp/Generic/Client/module-type-S/index.html} CoHTTP documentation}. *)
+module Client : sig
+  include
+    Cohttp.Generic.Client.S
+      with type 'a io = 'a
+      with type 'a with_context = 'a
+      with type body = Cohttp.Body.t
+end
+
+(** Convenience funtions for processing requests and constructing responses.
+
+    Please consult the
+    {{:https://ocaml.org/p/cohttp/latest/doc/Cohttp/Generic/Server/module-type-S/index.html} CoHTTP documentation}. *)
+module Server : sig
+  include
+    Cohttp.Generic.Server.S
+      with type 'a IO.t = 'a
+      with type IO.conn = Unix.file_descr
+      with type body = Cohttp.Body.t
+
+  val run : t -> IO.conn -> unit
+  (** [run server socket] starts running a server that {{!Unix.accept} accepts}
+      clients on the specified [socket].  This never returns normally. *)
+end

--- a/picos.opam
+++ b/picos.opam
@@ -16,6 +16,9 @@ depends: [
   "psq" {>= "0.2.1"}
   "multicore-magic" {>= "2.3.0"}
   "lwt" {>= "5.7.0"}
+  "cohttp" {>= "6.0.0~beta2"}
+  "uri" {>= "4.4.0"}
+  "fmt" {>= "0.9.0"}
   "multicore-bench" {>= "0.1.4" & with-test}
   "alcotest" {>= "1.7.0" & with-test}
   "qcheck-core" {>= "0.21.2" & with-test}
@@ -33,11 +36,9 @@ depends: [
   "ocaml" {>= "4.14.0"}
 ]
 depopts: [
-  "cohttp" {>= "5.3.1" & with-test}
   "cohttp-lwt" {>= "5.3.0" & with-test}
   "cohttp-lwt-unix" {>= "5.3.0" & with-test}
   "conduit-lwt-unix" {>= "6.2.2" & with-test}
-  "uri" {>= "4.4.0" & with-test}
 ]
 build: [
   ["dune" "subst"] {dev}

--- a/test/dune
+++ b/test/dune
@@ -93,6 +93,11 @@
   picos.structured
   alcotest))
 
+(test
+ (name test_stdio_cohttp)
+ (modules test_stdio_cohttp)
+ (libraries picos.finally picos.stdio.cohttp picos.structured test_scheduler))
+
 ;;
 
 (test

--- a/test/test_stdio_cohttp.ml
+++ b/test/test_stdio_cohttp.ml
@@ -1,0 +1,59 @@
+open Cohttp
+open Picos_finally
+open Picos_stdio
+open Picos_stdio_cohttp
+open Picos_structured
+
+let is_opam_ci =
+  match Sys.getenv "OPAM_REPO_CI" with
+  | _ -> true
+  | exception Not_found -> false
+
+let main () =
+  Printexc.record_backtrace true;
+
+  (* First we create, bind, and start listening on the server socket. *)
+  let@ server_socket =
+    finally Unix.close @@ fun () ->
+    Unix.socket ~cloexec:true PF_INET SOCK_STREAM 0
+  in
+  Unix.set_nonblock server_socket;
+  match Unix.bind server_socket Unix.(ADDR_INET (inet_addr_loopback, 0)) with
+  | exception Unix.Unix_error (EPERM, _, _) when is_opam_ci -> ()
+  | () ->
+      Unix.listen server_socket 8;
+      (* Then we start the server. *)
+      Flock.join_after @@ fun () ->
+      let server =
+        Flock.fork_as_promise @@ fun () ->
+        let callback _conn req body =
+          let uri = req |> Request.uri |> Uri.to_string in
+          let meth = req |> Request.meth |> Code.string_of_method in
+          let headers = req |> Request.headers |> Header.to_string in
+          let body = body |> Body.to_string in
+          let body =
+            Printf.sprintf "Uri: %s\nMethod: %s\n\n%sBody: %s" uri meth headers
+              body
+          in
+          Server.respond_string ~status:`OK ~body ()
+        in
+        Server.run (Server.make ~callback ()) server_socket
+      in
+      let server_uri =
+        match Unix.getsockname server_socket with
+        | ADDR_UNIX _ -> failwith "impossible"
+        | ADDR_INET (addr, port) ->
+            Printf.sprintf "http://%s:%d/hello-stdio-cohttp"
+              (Unix.string_of_inet_addr addr)
+              port
+      in
+      (* Then we call the server. *)
+      let _resp, body =
+        Client.post ~body:(`String "It's-a-Me, Picos!")
+          (Uri.of_string server_uri)
+      in
+      Printf.printf "%s\n%!" (Body.to_string body);
+      (* Finally we terminate the server. *)
+      Promise.terminate server
+
+let () = Test_scheduler.run ~max_domains:3 main


### PR DESCRIPTION
This PR adds minimalistic Cohttp `Client` and `Server` modules using `picos.stdio` for IO.

This also changes `Picos_select` to configure `SIGPIPE` to be ignored by default.  This makes it easier to deal with cases where one end of a communication is closed before the other end is done.

This is definitely not a final solution, but I need a minimalistic HTTP client and don't have time to think through how to support more interesting use cases in the best way with Cohttp.  Testing is also not very thorough at this point.  In other words, improvements, including highly likely breaking changes, are left for future work.

Feedback from potential users is welcome!