### PR TITLE
Fix off-by-one error in `read_line`

### DIFF
--- a/lib/picos_stdio_cohttp/picos_stdio_cohttp.ml
+++ b/lib/picos_stdio_cohttp/picos_stdio_cohttp.ml
@@ -85,7 +85,7 @@ module Private = struct
           i - Bool.to_int (0 < i && Bytes.get ic.bytes (ic.start + i - 1) = '\r')
         in
         let result = Some (Bytes.sub_string ic.bytes ic.start n) in
-        ic.start <- ic.start + i + Bool.to_int (ic.start + i < ic.stop - 1);
+        ic.start <- ic.start + i + Bool.to_int (ic.start + i < ic.stop);
         result
 
     let rec read_line_to_lf ic i =


### PR DESCRIPTION
Another bug found via randomization, see #225.