### PR TITLE
Add optional argument to terminate `Bundle` and `Flock` on return

### DIFF
--- a/bench/bench_bounded_q.ml
+++ b/bench/bench_bounded_q.ml
@@ -120,7 +120,7 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
   in
   let wrap _ () = Scheduler.run in
   let work domain_index () =
-    Flock.join_after @@ fun () ->
+    Flock.join_after ~on_return:`Terminate @@ fun () ->
     if not is_ocaml4 then Flock.fork yielder;
     if domain_index < n_adders then
       let rec work () =
@@ -131,7 +131,6 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
           done;
           work ()
         end
-        else Flock.terminate ()
       in
       work ()
     else
@@ -143,7 +142,6 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
           done;
           work ()
         end
-        else Flock.terminate ()
       in
       work ()
   in

--- a/bench/bench_memory.ml
+++ b/bench/bench_memory.ml
@@ -16,7 +16,7 @@ let run_suite ~budgetf:_ =
       begin
         Scheduler.run @@ fun () ->
         let open Picos_structured in
-        Bundle.join_after @@ fun bundle ->
+        Bundle.join_after ~on_return:`Terminate @@ fun bundle ->
         let n = 10_000 in
         let bytes =
           measure_live_bytes @@ fun () ->
@@ -30,7 +30,6 @@ let run_suite ~budgetf:_ =
           done;
           Control.yield ()
         in
-        Bundle.terminate bundle;
         Metric.make ~metric:"memory used" ~config:"fiber in a bundle" ~units:"B"
           ~trend:`Lower_is_better ~description:"Memory usage"
           (`Float (Float.of_int (bytes / n)))
@@ -38,7 +37,7 @@ let run_suite ~budgetf:_ =
       begin
         Scheduler.run @@ fun () ->
         let open Picos_structured in
-        Bundle.join_after @@ fun bundle ->
+        Bundle.join_after ~on_return:`Terminate @@ fun bundle ->
         let n = 10_000 in
         let bytes =
           measure_live_bytes @@ fun () ->
@@ -52,7 +51,6 @@ let run_suite ~budgetf:_ =
           done;
           Control.yield ()
         in
-        Bundle.terminate bundle;
         Metric.make ~metric:"memory used" ~config:"promise in a bundle"
           ~units:"B" ~trend:`Lower_is_better ~description:"Memory usage"
           (`Float (Float.of_int (bytes / n)))
@@ -60,7 +58,7 @@ let run_suite ~budgetf:_ =
       begin
         Scheduler.run @@ fun () ->
         let open Picos_structured in
-        Flock.join_after @@ fun () ->
+        Flock.join_after ~on_return:`Terminate @@ fun () ->
         let n = 10_000 in
         let bytes =
           measure_live_bytes @@ fun () ->
@@ -74,7 +72,6 @@ let run_suite ~budgetf:_ =
           done;
           Control.yield ()
         in
-        Flock.terminate ();
         Metric.make ~metric:"memory used" ~config:"fiber in a flock" ~units:"B"
           ~trend:`Lower_is_better ~description:"Memory usage"
           (`Float (Float.of_int (bytes / n)))
@@ -82,7 +79,7 @@ let run_suite ~budgetf:_ =
       begin
         Scheduler.run @@ fun () ->
         let open Picos_structured in
-        Flock.join_after @@ fun () ->
+        Flock.join_after ~on_return:`Terminate @@ fun () ->
         let n = 10_000 in
         let bytes =
           measure_live_bytes @@ fun () ->
@@ -96,7 +93,6 @@ let run_suite ~budgetf:_ =
           done;
           Control.yield ()
         in
-        Flock.terminate ();
         Metric.make ~metric:"memory used" ~config:"promise in a flock"
           ~units:"B" ~trend:`Lower_is_better ~description:"Memory usage"
           (`Float (Float.of_int (bytes / n)))

--- a/bench/bench_semaphore.ml
+++ b/bench/bench_semaphore.ml
@@ -24,8 +24,7 @@ let run_one ~budgetf ~use_domains ~n_resources () =
   let init _ = () in
   let wrap _ () = Scheduler.run in
   let work _ () =
-    Bundle.join_after @@ fun daemons ->
-    Fun.protect ~finally:(fun () -> Bundle.terminate daemons) @@ fun () ->
+    Bundle.join_after ~on_return:`Terminate @@ fun daemons ->
     let run_worker () =
       if not is_ocaml4 then Bundle.fork daemons yielder;
       for _ = 1 to n_ops do

--- a/lib/picos_select/picos_select.mli
+++ b/lib/picos_select/picos_select.mli
@@ -191,7 +191,7 @@ val check_configured : unit -> unit
           assert (w = 1)
         in
 
-        Flock.join_after begin fun () ->
+        Flock.join_after ~on_return:`Terminate begin fun () ->
           Flock.fork begin fun () ->
             while true do
               Event.select [
@@ -221,8 +221,6 @@ val check_configured : unit -> unit
           read1 syn_inn;
           write1 msg_out2;
           read1 syn_inn;
-
-          Flock.terminate ()
         end
       Inn1
       Inn2

--- a/lib/picos_stdio/picos_stdio.mli
+++ b/lib/picos_stdio/picos_stdio.mli
@@ -718,7 +718,7 @@ end
         Unix.set_nonblock syn_i;
         Unix.set_nonblock syn_o;
 
-        Flock.join_after begin fun () ->
+        Flock.join_after ~on_return:`Terminate begin fun () ->
           Flock.fork begin fun () ->
             let bytes = Bytes.create 100 in
             while true do
@@ -752,8 +752,6 @@ end
 
           send_string "Hello, world!";
           send_string "POSIX with OCaml";
-
-          Flock.terminate ()
         end
       Hello, world!
       POSIX with OCaml

--- a/lib/picos_stdio_cohttp/picos_stdio_cohttp.mli
+++ b/lib/picos_stdio_cohttp/picos_stdio_cohttp.mli
@@ -128,13 +128,11 @@ end
             ()
         in
 
-        Flock.join_after @@ fun () ->
+        Flock.join_after ~on_return:`Terminate @@ fun () ->
 
-        let@ server =
-          finally Promise.terminate @@ fun () ->
-          Flock.fork_as_promise @@ fun () ->
+        Flock.fork begin fun () ->
           server_run server_socket
-        in
+        end;
 
         client server_uri "World"
       - : string = "Hello, World!"
@@ -144,5 +142,5 @@ end
     ultimately the [server_uri] from it — typically one can avoid this
     complexity and use a fixed port.  We then create a
     {{!Picos_structured.Flock} flock} for running the server as a concurrent
-    promise, which we arrange to terminate at the end of the scope.  Finally we
+    fiber, which we arrange to terminate at the end of the scope.  Finally we
     act as the client to get a greeting from the server. *)

--- a/lib/picos_structured/flock.ml
+++ b/lib/picos_structured/flock.ml
@@ -9,4 +9,6 @@ let terminate ?callstack () = Bundle.terminate ?callstack (get ())
 let error ?callstack exn_bt = Bundle.error (get ()) ?callstack exn_bt
 let fork_as_promise thunk = Bundle.fork_as_promise_pass (get ()) thunk FLS
 let fork action = Bundle.fork_pass (get ()) action FLS
-let join_after fn = Bundle.join_after_pass fn Bundle.FLS
+
+let join_after ?callstack ?on_return fn =
+  Bundle.join_after_pass ?callstack ?on_return fn Bundle.FLS

--- a/lib/picos_sync/picos_sync.mli
+++ b/lib/picos_sync/picos_sync.mli
@@ -562,7 +562,7 @@ end
           Bounded_q.create ~capacity:3
         in
 
-        Flock.join_after begin fun () ->
+        Flock.join_after ~on_return:`Terminate begin fun () ->
           Flock.fork begin fun () ->
             while true do
               Printf.printf "Popped %d\n%!"
@@ -578,8 +578,6 @@ end
           Printf.printf "All done?\n%!";
 
           Control.yield ();
-
-          Flock.terminate ()
         end;
 
         Printf.printf "Pushing %d\n%!" 101;

--- a/test/test_server_and_client.ml
+++ b/test/test_server_and_client.ml
@@ -110,7 +110,7 @@ let main () =
   in
 
   begin
-    Flock.join_after @@ fun () ->
+    Flock.join_after ~on_return:`Terminate @@ fun () ->
     Flock.fork server;
     begin
       Mutex.protect mutex @@ fun () ->
@@ -118,8 +118,7 @@ let main () =
         Condition.wait condition mutex
       done
     end;
-    Run.all [ client "A"; client "B" ];
-    Flock.terminate ()
+    Run.all [ client "A"; client "B" ]
   end;
 
   Printf.printf "Server and Client test: OK\n%!"

--- a/test/test_stdio.ml
+++ b/test/test_stdio.ml
@@ -46,14 +46,13 @@ let test_select_empty_timeout () =
 
 let test_select_empty_forever () =
   Test_scheduler.run ~max_domains:2 @@ fun () ->
-  Flock.join_after @@ fun () ->
+  Flock.join_after ~on_return:`Terminate @@ fun () ->
   begin
     Flock.fork @@ fun () ->
     let _ = Unix.select [] [] [] (-1.0) in
     Printf.printf "Impossible\n%!"
   end;
-  Unix.sleepf 0.01;
-  Flock.terminate ()
+  Unix.sleepf 0.01
 
 let test_select () =
   Test_scheduler.run ~max_domains:2 @@ fun () ->
@@ -79,39 +78,39 @@ let test_select () =
 
   let events = Picos_mpscq.create ~padded:true () in
 
-  Flock.join_after @@ fun () ->
   begin
-    Flock.fork @@ fun () ->
-    while true do
-      match Unix.select [ msg_inn1; msg_inn2 ] [] [] 0.2 with
-      | inns, _, _ ->
-          if List.exists (( == ) msg_inn1) inns then begin
-            Picos_mpscq.push events (Printf.sprintf "Inn1");
-            assert (1 = Unix.read msg_inn1 (Bytes.create 1) 0 1);
-            assert (1 = Unix.write_substring syn_out "!" 0 1)
-          end;
-          if List.exists (( == ) msg_inn2) inns then begin
-            Picos_mpscq.push events (Printf.sprintf "Inn2");
-            assert (1 = Unix.read msg_inn2 (Bytes.create 1) 0 1);
-            assert (1 = Unix.write_substring syn_out "!" 0 1)
-          end;
-          if [] == inns then begin
-            Picos_mpscq.push events (Printf.sprintf "Timeout");
-            assert (1 = Unix.write_substring syn_out "!" 0 1)
-          end
-    done
+    Flock.join_after ~on_return:`Terminate @@ fun () ->
+    begin
+      Flock.fork @@ fun () ->
+      while true do
+        match Unix.select [ msg_inn1; msg_inn2 ] [] [] 0.2 with
+        | inns, _, _ ->
+            if List.exists (( == ) msg_inn1) inns then begin
+              Picos_mpscq.push events (Printf.sprintf "Inn1");
+              assert (1 = Unix.read msg_inn1 (Bytes.create 1) 0 1);
+              assert (1 = Unix.write_substring syn_out "!" 0 1)
+            end;
+            if List.exists (( == ) msg_inn2) inns then begin
+              Picos_mpscq.push events (Printf.sprintf "Inn2");
+              assert (1 = Unix.read msg_inn2 (Bytes.create 1) 0 1);
+              assert (1 = Unix.write_substring syn_out "!" 0 1)
+            end;
+            if [] == inns then begin
+              Picos_mpscq.push events (Printf.sprintf "Timeout");
+              assert (1 = Unix.write_substring syn_out "!" 0 1)
+            end
+      done
+    end;
+
+    Control.yield ();
+    assert (1 = Unix.write_substring msg_out1 "!" 0 1);
+    Control.yield ();
+    assert (1 = Unix.write_substring msg_out2 "!" 0 1);
+    Control.yield ();
+    assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
+    assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
+    assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1)
   end;
-
-  Control.yield ();
-  assert (1 = Unix.write_substring msg_out1 "!" 0 1);
-  Control.yield ();
-  assert (1 = Unix.write_substring msg_out2 "!" 0 1);
-  Control.yield ();
-  assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
-  assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
-  assert (1 = Unix.read syn_inn (Bytes.create 1) 0 1);
-
-  Flock.terminate ();
 
   let events = Picos_mpscq.pop_all events in
 


### PR DESCRIPTION
Having a `Bundle` or `Flock` terminate fibers on return is often convenient. In particular, this is convenient for setting up a bundle for daemon fibers:

```ocaml
Bundle.join_after ~on_return:`Terminate @@ fun daemons ->
Bundle.fork daemons (fun () -> (* ... *))
(* ... *)
```

Another alternative (one of many) is to fork as a promise and use a finalizer:

```ocaml
let@ _daemon =
  finally Promise.terminate @@ fun () ->
  Flock.fork_as_promise @@ fun () ->
  (* ... *)
in
(* ... *)
```