### PR TITLE
Add `Picos_mpmcq.length` and tweak for performance

### DIFF
--- a/lib/picos_mpmcq/picos_mpmcq.mli
+++ b/lib/picos_mpmcq/picos_mpmcq.mli
@@ -31,6 +31,13 @@ val pop_exn : 'a t -> 'a
 
     @raise Empty in case the queue was empty. *)
 
+val length : 'a t -> int
+(** [length queue] returns the length or the number of values
+    in the [queue]. *)
+
+val is_empty : 'a t -> bool
+(** [is_empty queue] is equivalent to {{!length} [length queue = 0]}. *)
+
 (** {1 Examples}
 
     An example top-level session:
@@ -44,6 +51,9 @@ val pop_exn : 'a t -> 'a
 
       # Picos_mpmcq.push_head q 76
       - : unit = ()
+
+      # Picos_mpmcq.length q
+      - : int = 2
 
       # Picos_mpmcq.push q 101
       - : unit = ()


### PR DESCRIPTION
The tweaks clearly improved performance on my Apple M3 Max laptop, but improvements on the AMD Zen 1 and Opteron benchmarking servers are unclear.

```
➜  picos-this git:(add-length-to-queue-and-tweaks) ✗ dune exec --release -- ./bench/main.exe -budget 2 -diff bench-mpmcq-hi.json
Picos_mpmcq:                          
  time per message/one domain:
    16.20 ns = 1.00 x 16.25 ns
  messages over time/one domain:
    61.72 M/s = 1.00 x 61.54 M/s
  time per message/1 nb adder, 1 nb taker:
    15.27 ns = 0.82 x 18.70 ns
  messages over time/1 nb adder, 1 nb taker:
    130.95 M/s = 1.22 x 106.94 M/s
  time per message/1 nb adder, 2 nb takers:
    28.30 ns = 0.91 x 31.09 ns
  messages over time/1 nb adder, 2 nb takers:
    106.02 M/s = 1.10 x 96.49 M/s
  time per message/2 nb adders, 1 nb taker:
    31.32 ns = 0.92 x 34.14 ns
  messages over time/2 nb adders, 1 nb taker:
    95.79 M/s = 1.09 x 87.88 M/s
  time per message/2 nb adders, 2 nb takers:
    42.58 ns = 0.90 x 47.07 ns
  messages over time/2 nb adders, 2 nb takers:
    93.94 M/s = 1.11 x 84.99 M/s
```
