### PR TITLE
add `Picos.Computation.peek_exn`

### DIFF
--- a/lib/picos/bootstrap/picos_bootstrap.ml
+++ b/lib/picos/bootstrap/picos_bootstrap.ml
@@ -314,6 +314,16 @@ module Computation = struct
         if tx == Stopped then Exn_bt.raise exn_bt
     | S (Returned _) | S (Continue _) -> ()
 
+  exception Running
+
+  let peek_exn t =
+    match Atomic.get t with
+    | S (Canceled { exn_bt; tx; _ }) ->
+        if tx == Stopped then Exn_bt.raise exn_bt else raise_notrace Running
+    | S (Returned { value; tx; _ }) ->
+        if tx == Stopped then value else raise_notrace Running
+    | S (Continue _) -> raise_notrace Running
+
   let peek t =
     match Atomic.get t with
     | S (Canceled { exn_bt; tx; _ }) ->

--- a/lib/picos/ocaml5/picos_ocaml.ml
+++ b/lib/picos/ocaml5/picos_ocaml.ml
@@ -63,7 +63,7 @@ module Handler = struct
       Some
         (fun k ->
           match h.yield c with
-          | unit -> Effect.Deep.continue k unit
+          | () -> Effect.Deep.continue k ()
           | exception exn -> discontinue k exn)
     in
     let effc (type a) :

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -653,17 +653,16 @@ module Computation : sig
       the computation has not completed. *)
 
   exception Running
-  (** Exception raised by {!peek_exn} when it's used on a
-      still running computation. This should never be surfaced
-      to the user. *)
+  (** Exception raised by {!peek_exn} when it's used on a still running
+      computation.  This should never be surfaced to the user. *)
 
   val peek_exn : 'a t -> 'a
-  (** [peek_exn computation] returns the result of the computation
-      or raises an exception. It is important to catch at
-      least the {!Running} exception as it's raised without a backtrace.
-      If the computation was cancelled with exception [exn] then
-      [exn] is re-raised with its original backtrace.
-      @raise Running is called if the computation has not completed. *)
+  (** [peek_exn computation] returns the result of the computation or raises an
+      exception.  It is important to catch the exception.  If the computation
+      was cancelled with exception [exn] then [exn] is re-raised with its
+      original backtrace.
+
+      @raise Running if the computation has not completed. *)
 
   (** {2 Interface for awaiting} *)
 

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -653,6 +653,9 @@ module Computation : sig
       the computation has not completed. *)
 
   exception Running
+  (** Exception raised by {!peek_exn} when it's used on a
+      still running computation. This should never be surfaced
+      to the user. *)
 
   val peek_exn : 'a t -> 'a
   (** [peek_exn computation] returns the result of the computation

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -656,10 +656,11 @@ module Computation : sig
 
   val peek_exn : 'a t -> 'a
   (** [peek_exn computation] returns the result of the computation
-        or raises an exception. It is important to catch the exception.
-        If the computation was cancelled with exception [exn] then
-        [exn] is re-raised with its original backtrace.
-        @raise Running is called if the computation has not completed *)
+      or raises an exception. It is important to catch at
+      least the {!Running} exception as it's raised without a backtrace.
+      If the computation was cancelled with exception [exn] then
+      [exn] is re-raised with its original backtrace.
+      @raise Running is called if the computation has not completed. *)
 
   (** {2 Interface for awaiting} *)
 

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -652,6 +652,15 @@ module Computation : sig
   (** [peek computation] returns the result of the computation or [None] in case
       the computation has not completed. *)
 
+  exception Running
+
+  val peek_exn : 'a t -> 'a
+  (** [peek_exn computation] returns the result of the computation
+        or raises an exception. It is important to catch the exception.
+        If the computation was cancelled with exception [exn] then
+        [exn] is re-raised with its original backtrace.
+        @raise Running is called if the computation has not completed *)
+
   (** {2 Interface for awaiting} *)
 
   val try_attach : 'a t -> Trigger.t -> bool

--- a/lib/picos_exn_bt/picos_exn_bt.ocaml4.ml
+++ b/lib/picos_exn_bt/picos_exn_bt.ocaml4.ml
@@ -1,12 +1,12 @@
 include Common
 
-let get exn =
+let[@inline always] get exn =
   let bt = Printexc.get_raw_backtrace () in
   { exn; bt }
 
 let empty_backtrace = Printexc.get_callstack 0
 
-let get_callstack n exn =
+let[@inline always] get_callstack n exn =
   let bt = if n <= 0 then empty_backtrace else Printexc.get_callstack n in
   { exn; bt }
 

--- a/lib/picos_exn_bt/picos_exn_bt.ocaml4.ml
+++ b/lib/picos_exn_bt/picos_exn_bt.ocaml4.ml
@@ -1,5 +1,7 @@
 include Common
 
+(* We always inline [get] and [get_callstack] to get correct callstacks. *)
+
 let[@inline always] get exn =
   let bt = Printexc.get_raw_backtrace () in
   { exn; bt }

--- a/lib/picos_exn_bt/picos_exn_bt.ocaml5.ml
+++ b/lib/picos_exn_bt/picos_exn_bt.ocaml5.ml
@@ -1,12 +1,12 @@
 include Common
 
-let get exn =
+let[@inline always] get exn =
   let bt = Printexc.get_raw_backtrace () in
   { exn; bt }
 
 let empty_backtrace = Printexc.get_callstack 0
 
-let get_callstack n exn =
+let[@inline always] get_callstack n exn =
   let bt = if n <= 0 then empty_backtrace else Printexc.get_callstack n in
   { exn; bt }
 

--- a/lib/picos_exn_bt/picos_exn_bt.ocaml5.ml
+++ b/lib/picos_exn_bt/picos_exn_bt.ocaml5.ml
@@ -1,5 +1,7 @@
 include Common
 
+(* We always inline [get] and [get_callstack] to get correct callstacks. *)
+
 let[@inline always] get exn =
   let bt = Printexc.get_raw_backtrace () in
   { exn; bt }


### PR DESCRIPTION
`peek` is often used in the fast path of some operations, so
ideally it should not allocate.
