### PR TITLE
add `Fiber.copy_fls`

### DIFF
--- a/lib/picos/bootstrap/picos_bootstrap.ml
+++ b/lib/picos/bootstrap/picos_bootstrap.ml
@@ -381,6 +381,9 @@ module Fiber = struct
 
   let has_forbidden (Fiber r : t) = r.forbid
 
+  let copy_fls (Fiber f1 : t) (Fiber f2 : t) : unit =
+    f2.fls <- Array.copy f1.fls
+
   let is_canceled (Fiber r : t) =
     (not r.forbid)
     &&

--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -1122,6 +1122,10 @@ module Fiber : sig
 
   (** {2 Interface for schedulers} *)
 
+  val copy_fls : t -> t -> unit
+  (** [copy_fls fiber1 fiber2] copies the {!FLS} internal state of
+      [fiber1] into [fiber2]'s. *)
+
   val try_suspend :
     t -> Trigger.t -> 'x -> 'y -> (Trigger.t -> 'x -> 'y -> unit) -> bool
   (** [try_suspend fiber trigger x y resume] tries to suspend the [fiber] to


### PR DESCRIPTION
this is useful for forms of structured concurrency where fls
is inherited from parents in children.
