### PR TITLE
Use same STM test count and time budgets on all targets

### DIFF
--- a/test/stm_run/intf.ml
+++ b/test/stm_run/intf.ml
@@ -43,3 +43,6 @@ module type STM_domain = sig
   val agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
   val neg_agree_test_par_asym : count:int -> name:string -> QCheck.Test.t
 end
+
+let default_count = 1_000
+let default_budgetf = 60.0

--- a/test/stm_run/stm_run.ocaml4.ml
+++ b/test/stm_run/stm_run.ocaml4.ml
@@ -1,11 +1,7 @@
 include Intf
 
-let count =
-  let factor b = if b then 10 else 1 in
-  factor (64 <= Sys.word_size) * factor (Sys.backend_type = Native) * 10
-
-let run ?(verbose = true) ?(count = count) ?(budgetf = 60.0) ~name ?make_domain
-    (module Spec : STM.Spec) =
+let run ?(verbose = true) ?(count = default_count) ?(budgetf = default_budgetf)
+    ~name ?make_domain (module Spec : STM.Spec) =
   let module Seq = STM_sequential.Make (Spec) in
   let module Con = STM_thread.Make (Spec) [@alert "-experimental"] in
   Util.run_with_budget ~budgetf ~count @@ fun count ->

--- a/test/stm_run/stm_run.ocaml5.ml
+++ b/test/stm_run/stm_run.ocaml5.ml
@@ -1,13 +1,7 @@
 include Intf
 
-let count =
-  let factor b = if b then 10 else 1 in
-  factor (64 <= Sys.word_size)
-  * factor (Sys.backend_type = Native)
-  * factor (1 < Domain.recommended_domain_count ())
-
-let run (type cmd state sut) ?(verbose = true) ?(count = count)
-    ?(budgetf = 60.0) ~name ?make_domain
+let run (type cmd state sut) ?(verbose = true) ?(count = default_count)
+    ?(budgetf = default_budgetf) ~name ?make_domain
     (module Spec : STM.Spec
       with type cmd = cmd
        and type state = state


### PR DESCRIPTION
This is now possible, because the tests are being run with a time based budget and that prevents tests from taking way too long on slower targets.