### PR TITLE
Test cross scheduler wakeup

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -228,11 +228,15 @@
  (modules test_schedulers)
  (libraries
   alcotest
+  backoff
+  domain_shims
   picos
+  picos_std.finally
   picos_std.structured
   picos_std.sync
   test_scheduler
-  test_util))
+  test_util
+  unix))
 
 ;;
 


### PR DESCRIPTION
Working to port Kcas to Picos I noticed some (I believe) lost wakeups causing benchmarks to never finish.  This test exercises a similar scenario, running schedulers on two domains.  This doesn't seem to reproduce the issue however.  The mutex and condition cancelation test also works on all the schedulers (at least on macOS).