### PR TITLE
Raise proper error when select has not been configured

### DIFF
--- a/lib/picos_lwt.unix/picos_lwt_unix.ml
+++ b/lib/picos_lwt.unix/picos_lwt_unix.ml
@@ -82,5 +82,3 @@ let run ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber fiber main |> Lwt.map @@ fun () -> Computation.await computation
-
-let () = Lwt_main.run (Lwt_unix.sleep 0.0)

--- a/test/test_io_with_lwt.ml
+++ b/test/test_io_with_lwt.ml
@@ -1,6 +1,7 @@
 open Picos_io
 
 let test_system_unix () =
+  Test_scheduler.init ();
   let sleep = Lwt_unix.system "sleep 2" in
   Lwt_main.run @@ Lwt.bind sleep
   @@ fun _status ->

--- a/test/test_sync.ml
+++ b/test/test_sync.ml
@@ -65,6 +65,7 @@ let test_mutex_and_condition_errors () =
   end
 
 let test_mutex_and_condition_cancelation () =
+  Test_scheduler.init ();
   let mutex = Mutex.create () in
   let condition = Condition.create () in
 


### PR DESCRIPTION
Also do not configure select during module level initialization in the test scheduler.
