### PR TITLE
Use the new `Computation.peek_exn` when computation is completed

### DIFF
--- a/lib/picos_io.select/picos_io_select.ml
+++ b/lib/picos_io.select/picos_io_select.ml
@@ -477,7 +477,7 @@ module Intr = struct
        end
 
   let intr_action trigger (Req r as req : [ `Req ] tdt) id =
-    match Computation.await r.computation with
+    match Computation.peek_exn r.computation with
     | Cleared ->
         (* No signal needs to be delivered. *)
         remove_action trigger r.state id

--- a/lib/picos_io/picos_io.ml
+++ b/lib/picos_io/picos_io.ml
@@ -411,9 +411,9 @@ module Unix = struct
               else zip_filter pred xs ys
           | _, _ -> []
         in
-        ( zip_filter Computation.await rds rdcs,
-          zip_filter Computation.await wrs wrcs,
-          zip_filter Computation.await exs excs )
+        ( zip_filter Computation.peek_exn rds rdcs,
+          zip_filter Computation.peek_exn wrs wrcs,
+          zip_filter Computation.peek_exn exs excs )
     | exception cancelation_exn ->
         Computation.cancel overall Done empty_bt;
         raise cancelation_exn

--- a/lib/picos_lwt.unix/picos_lwt_unix.ml
+++ b/lib/picos_lwt.unix/picos_lwt_unix.ml
@@ -81,4 +81,4 @@ let run ?(forbid = false) main =
   let computation = Computation.create ~mode:`LIFO () in
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
-  run_fiber fiber main |> Lwt.map @@ fun () -> Computation.await computation
+  run_fiber fiber main |> Lwt.map @@ fun () -> Computation.peek_exn computation

--- a/lib/picos_lwt/picos_lwt.ml
+++ b/lib/picos_lwt/picos_lwt.ml
@@ -26,12 +26,12 @@ let await promise =
       let trigger = Trigger.create () in
       if Computation.try_attach computation trigger then begin
         match Trigger.await trigger with
-        | None -> Computation.await computation
+        | None -> Computation.peek_exn computation
         | Some (exn, bt) ->
             Lwt.cancel promise;
             Printexc.raise_with_backtrace exn bt
       end
-      else Computation.await computation
+      else Computation.peek_exn computation
   | Return value -> value
   | Fail exn -> raise exn
 
@@ -112,4 +112,4 @@ let run ?(forbid = false) system main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber system fiber main
-  |> Lwt.map @@ fun () -> Computation.await computation
+  |> Lwt.map @@ fun () -> Computation.peek_exn computation

--- a/lib/picos_mux.fifo/picos_mux_fifo.ml
+++ b/lib/picos_mux.fifo/picos_mux_fifo.ml
@@ -225,4 +225,4 @@ let run ?quota ?fatal_exn_handler ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber ?quota ?fatal_exn_handler fiber main;
-  Computation.await computation
+  Computation.peek_exn computation

--- a/lib/picos_mux.multififo/picos_mux_multififo.ml
+++ b/lib/picos_mux.multififo/picos_mux_multififo.ml
@@ -409,7 +409,7 @@ let run ?context ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber ?context fiber main;
-  Computation.await computation
+  Computation.peek_exn computation
 
 let rec run_fiber_on n fiber main runner_main context =
   if n <= 1 then run_fiber ~context fiber main
@@ -460,4 +460,4 @@ let run_on ?quota ?fatal_exn_handler ~n_domains ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber_on ?quota ?fatal_exn_handler ~n_domains fiber main;
-  Computation.await computation
+  Computation.peek_exn computation

--- a/lib/picos_mux.random/picos_mux_random.ml
+++ b/lib/picos_mux.random/picos_mux_random.ml
@@ -299,7 +299,7 @@ let run ?context ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber ?context fiber main;
-  Computation.await computation
+  Computation.peek_exn computation
 
 let rec run_fiber_on n fiber main runner_main context =
   if n <= 1 then run_fiber ~context fiber main
@@ -351,4 +351,4 @@ let run_on ?fatal_exn_handler ~n_domains ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber_on ?fatal_exn_handler ~n_domains fiber main;
-  Computation.await computation
+  Computation.peek_exn computation

--- a/lib/picos_mux.thread/picos_mux_thread.ml
+++ b/lib/picos_mux.thread/picos_mux_thread.ml
@@ -98,4 +98,4 @@ let run ?(forbid = false) ?fatal_exn_handler main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber ?fatal_exn_handler fiber main;
-  Computation.await computation
+  Computation.peek_exn computation

--- a/lib/picos_std.event/event.ml
+++ b/lib/picos_std.event/event.ml
@@ -51,7 +51,7 @@ let sync_as : type a n. n -> (a, n) tycon -> a =
               if Computation.try_cancel target exn bt then
                 Printexc.raise_with_backtrace exn bt
       end;
-      Computation.await target ()
+      Computation.peek_exn target ()
   | exception exn ->
       let bt = Printexc.get_raw_backtrace () in
       Computation.cancel target exn bt;
@@ -65,7 +65,7 @@ let guard create_event =
 
 let[@alert "-handler"] from_computation source =
   let request target to_result =
-    let result () = to_result (Computation.await source) in
+    let result () = to_result (Computation.peek_exn source) in
     if Computation.is_running source then begin
       let propagator =
         Trigger.from_action result target @@ fun _ result target ->

--- a/lib/picos_std.sync/ivar.ml
+++ b/lib/picos_std.sync/ivar.ml
@@ -11,7 +11,9 @@ let try_poison = Computation.try_cancel
 let poison = Computation.cancel
 
 let peek_opt ivar =
-  if Computation.is_running ivar then None else Some (Computation.await ivar)
+  match Computation.peek_exn ivar with
+  | value -> Some value
+  | exception Computation.Running -> None
 
 let read = Computation.await
 let read_evt = Event.from_computation

--- a/lib/picos_std.sync/stream.ml
+++ b/lib/picos_std.sync/stream.ml
@@ -13,7 +13,7 @@ let[@inline] advance t tail curr =
     Atomic.compare_and_set t (Cons tail) curr |> ignore
 
 let[@inline] help t tail =
-  let _, curr = Computation.await tail in
+  let _, curr = Computation.peek_exn tail in
   advance t tail curr
 
 let rec push t ((_, curr) as next) backoff =
@@ -37,7 +37,9 @@ let rec poison t exn bt backoff =
   end
 
 let peek_opt (Cons at) =
-  if Computation.is_running at then None else Some (Computation.await at)
+  match Computation.peek_exn at with
+  | value -> Some value
+  | exception Computation.Running -> None
 
 let poison t exn bt = poison t exn bt Backoff.default
 let tap = Atomic.get


### PR DESCRIPTION
The new `Computation.peek_exn` should be preferred over `Computation.await` in cases where the computation is supposed to be completed already.