### PR TITLE
Add `run_main`

### DIFF
--- a/lib/picos_lwt.unix/picos_lwt_unix.ml
+++ b/lib/picos_lwt.unix/picos_lwt_unix.ml
@@ -82,3 +82,5 @@ let run ?(forbid = false) main =
   let fiber = Fiber.create ~forbid computation in
   let main _ = Computation.capture computation main () in
   run_fiber fiber main |> Lwt.map @@ fun () -> Computation.peek_exn computation
+
+let run_main ?forbid main = Lwt_main.run (run ?forbid main)

--- a/lib/picos_lwt.unix/picos_lwt_unix.mli
+++ b/lib/picos_lwt.unix/picos_lwt_unix.mli
@@ -17,3 +17,6 @@ val run : ?forbid:bool -> (unit -> 'a) -> 'a Lwt.t
 
     The optional [forbid] argument defaults to [false] and determines whether
     propagation of cancelation is initially allowed. *)
+
+val run_main : ?forbid:bool -> (unit -> 'a) -> 'a
+(** [run_main main] is equivalent to {{!run} [Lwt_main.run (run main)]}. *)


### PR DESCRIPTION
This is convenient for use with MDX, which does some magic when you refer to `Lwt`, which can break things.