### PR TITLE
Also retry `socketpair` on `ENOENT` on Windows

### DIFF
--- a/lib/picos_io/picos_io.ml
+++ b/lib/picos_io/picos_io.ml
@@ -440,7 +440,7 @@ module Unix = struct
           retries =
         match Unix.socketpair ?cloexec socket_domain socket_type mystery with
         | sockets -> sockets
-        | exception Unix.Unix_error ((EACCES | EADDRINUSE), _, _)
+        | exception Unix.Unix_error ((EACCES | EADDRINUSE | ENOENT), _, _)
           when 0 < retries ->
             socketpair_win32 ?cloexec socket_domain socket_type mystery
               (retries - 1)


### PR DESCRIPTION
This is yet another error that `Unix.socketpair` may raise on Windows, see #259.