### PR TITLE
Try `cpu_relax` while yielding to keep domain running

### DIFF
--- a/bench/bench_bounded_q.ml
+++ b/bench/bench_bounded_q.ml
@@ -102,7 +102,8 @@ let run_one_domain ~budgetf ?(n_msgs = 25 * Util.iter_factor) () =
 (** This will keep a domain running. *)
 let yielder () =
   while true do
-    Control.yield ()
+    Control.yield ();
+    Backoff.once Backoff.default |> ignore
   done
 
 let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =


### PR DESCRIPTION
The theory is that this might help reduce contention and improve performance.