### PR TITLE
Tweak conditionals with CAS

### DIFF
--- a/lib/picos/fiber.bootstrap.ml
+++ b/lib/picos/fiber.bootstrap.ml
@@ -65,11 +65,12 @@ let try_suspend (Fiber r : t) trigger x y resume =
   let (Packed computation) = r.packed in
   if not r.forbid then begin
     if Computation.try_attach computation trigger then
-      Trigger.on_signal trigger x y resume
-      || begin
-           Computation.detach computation trigger;
-           false
-         end
+      let success = Trigger.on_signal trigger x y resume in
+      if success then success
+      else begin
+        Computation.detach computation trigger;
+        false
+      end
     else if Computation.is_canceled computation then begin
       Trigger.dispose trigger;
       false

--- a/lib/picos/trigger.bootstrap.ml
+++ b/lib/picos/trigger.bootstrap.ml
@@ -36,7 +36,9 @@ let rec on_signal t x y action =
   | Signaled -> false
   | Awaiting _ -> error_awaiting ()
   | Initial ->
-      Atomic.compare_and_set t Initial (Awaiting { action; x; y })
-      || on_signal t x y action
+      let success =
+        Atomic.compare_and_set t Initial (Awaiting { action; x; y })
+      in
+      if success then success else on_signal t x y action
 
 let from_action x y action = Atomic.make (Awaiting { action; x; y })

--- a/lib/picos_std.sync/semaphore.ml
+++ b/lib/picos_std.sync/semaphore.ml
@@ -84,8 +84,8 @@ module Counting = struct
     0 < count
     &&
     let after = Obj.repr (count - 1) in
-    Atomic.compare_and_set t before after
-    || try_acquire t (Backoff.once backoff)
+    let success = Atomic.compare_and_set t before after in
+    if success then success else try_acquire t (Backoff.once backoff)
 
   let get_value t =
     let state = Atomic.get t in


### PR DESCRIPTION
It seems the native OCaml compiler generates suboptimal code when one uses the `||` or the `&&` operators.
