### PR TITLE
Add `Awaitable` atomic locations

### DIFF
--- a/bench/bench_binaries.ml
+++ b/bench/bench_binaries.ml
@@ -25,6 +25,7 @@ let paths =
     lib "picos_mux.multififo";
     lib "picos_mux.random";
     lib "picos_mux.thread";
+    lib "picos_std.awaitable";
     lib "picos_std.event";
     lib "picos_std.finally";
     lib "picos_std.structured";

--- a/bench/dune
+++ b/bench/dune
@@ -38,6 +38,7 @@
   picos_aux.mpscq
   picos_io
   picos_io.select
+  picos_std.awaitable
   picos_std.finally
   picos_std.structured
   picos_std.sync

--- a/lib/picos_std.awaitable/dune
+++ b/lib/picos_std.awaitable/dune
@@ -1,0 +1,11 @@
+(library
+ (name picos_std_awaitable)
+ (public_name picos_std.awaitable)
+ (libraries picos picos_aux.htbl backoff multicore-magic))
+
+(mdx
+ (package picos_meta)
+ (enabled_if
+  (>= %{ocaml_version} 5.0.0))
+ (libraries picos picos_std.awaitable)
+ (files picos_std_awaitable.mli))

--- a/lib/picos_std.awaitable/picos_std_awaitable.ml
+++ b/lib/picos_std.awaitable/picos_std_awaitable.ml
@@ -1,0 +1,430 @@
+module Awaitable = struct
+  type 'a t = { mutable _value : 'a; bits : int }
+
+  external as_atomic : 'a t -> 'a Atomic.t = "%identity"
+
+  let make ?padded value =
+    Multicore_magic.copy_as ?padded { _value = value; bits = Random.bits () }
+
+  let make_contended value = make ~padded:true value
+  let[@inline] get t = Atomic.get (Sys.opaque_identity (as_atomic t))
+  let[@inline] compare_and_set x b a = Atomic.compare_and_set (as_atomic x) b a
+  let[@inline] exchange t value = Atomic.exchange (as_atomic t) value
+  let[@inline] fetch_and_add t n = Atomic.fetch_and_add (as_atomic t) n
+  let[@inline] set t value = exchange t value |> ignore
+  let[@inline] incr t = fetch_and_add t 1 |> ignore
+  let[@inline] decr t = fetch_and_add t (-1) |> ignore
+
+  (* *)
+
+  open Picos
+
+  type 'a awaitable = 'a t
+
+  module Packed = struct
+    type t = Packed : 'a awaitable -> t [@@unboxed]
+
+    let equal = ( == )
+    let hash (Packed awaitable) = awaitable.bits
+  end
+
+  module Awaiters = struct
+    type _ tdt =
+      | Zero : [> `Zero ] tdt
+      | One : {
+          awaitable : 'a awaitable; (* Might also want to clear this *)
+          mutable value : 'a; (* This is mutable to avoid space leaks *)
+          trigger : Trigger.t;
+          mutable counter : int;
+          mutable next : min0;
+        }
+          -> [> `One ] tdt
+      | Many : { head : is1; prev : is1; tail : is1 } -> [> `Many ] tdt
+
+    and min0 = Min0 : [< `Zero | `One ] tdt -> min0 [@@unboxed]
+    and min1 = Min1 : [< `One | `Many ] tdt -> min1 [@@unboxed]
+    and is1 = [ `One ] tdt
+
+    let[@inline] exec (Many r : [ `Many ] tdt) =
+      if r.prev != r.tail then
+        let (One prev_r) = r.prev in
+        if prev_r.next == Min0 Zero then prev_r.next <- Min0 r.tail
+
+    let[@inline] snoc t (One tail_r as tail) =
+      match t with
+      | Min1 (One head_r) ->
+          tail_r.counter <- head_r.counter + 1;
+          Many { head = One head_r; prev = One head_r; tail }
+      | Min1 (Many many_r as many) ->
+          exec many;
+          let (One prev_r as prev) = many_r.tail in
+          tail_r.counter <- prev_r.counter + 1;
+          Many { head = many_r.head; prev; tail }
+
+    external as1 : min0 -> is1 = "%identity"
+
+    let[@inline] awaitable_of (One r : is1) = Packed.Packed r.awaitable
+    let[@inline] counter_of (One r : is1) = r.counter
+
+    let[@inline] next_of (One r : is1) ~tail =
+      let next = as1 r.next in
+      let counter = r.counter in
+      if counter_of tail - counter < counter_of next - counter then tail
+      else next
+
+    let[@inline] set_next_of (One one_r : is1) (next : is1) =
+      one_r.next <- Min0 next
+
+    let[@inline] generalize (One r : is1) = One r
+    let[@inline] is_signaled (One r : is1) = Trigger.is_signaled r.trigger
+    let[@inline] is_signalable (One r : is1) = get r.awaitable != r.value
+    let[@inline] await (One r : is1) = Trigger.await r.trigger
+    let[@inline] clear (One r : is1) = r.value <- Obj.magic ()
+
+    let[@inline] signal_and_clear (One r : is1) =
+      Trigger.signal r.trigger;
+      r.value <- Obj.magic ()
+
+    let[@inline] last (one : is1) =
+      if is_signaled one then Zero else generalize one
+
+    let[@inline] signal_last_one (one : is1) =
+      if is_signalable one then begin
+        signal_and_clear one;
+        Zero
+      end
+      else last one
+
+    let cleanup awaiters ~count =
+      let count = ref count in
+      match awaiters with
+      | Min1 (One r) -> last (One r)
+      | Min1 (Many many_r as many) ->
+          exec many;
+          let tail = many_r.tail in
+          let head = ref tail in
+          let work = ref many_r.head in
+          while !work != tail do
+            if is_signaled !work then begin
+              let next = next_of !work ~tail in
+              let n = !count - 1 in
+              count := n;
+              if n <> 0 then work := next
+              else begin
+                head := next;
+                work := tail
+              end
+            end
+            else begin
+              head := !work;
+              work := tail
+            end
+          done;
+          let head = !head in
+          if head == tail then begin
+            last head
+          end
+          else begin
+            if !count <> 0 then begin
+              let prev = ref head in
+              let work = ref (next_of !prev ~tail) in
+              while !work != tail do
+                let next = next_of !work ~tail in
+                if is_signaled !work then begin
+                  set_next_of !prev next;
+                  let n = !count - 1 in
+                  count := n;
+                  if n <> 0 then work := next else work := tail
+                end
+                else begin
+                  prev := !work;
+                  work := next
+                end
+              done;
+              if !count <> 0 && is_signaled tail then clear tail
+            end;
+            Many { head; prev = tail; tail }
+          end
+
+    let ( (* test cleanup *) ) =
+      if false then begin
+        [ 1; Int.max_int ]
+        |> List.iter @@ fun count ->
+           for n = 1 to 4 do
+             for bits = 0 to (1 lsl n) - 1 do
+               let make i =
+                 let trigger = Trigger.create () in
+                 if bits land (1 lsl i) = 0 then Trigger.signal trigger;
+                 let awaitable = make 0 and next = Min0 Zero in
+                 One { awaitable; value = 1; trigger; counter = 0; next }
+               in
+               let queue = ref (Min1 (make 0)) in
+               for i = 1 to n - 1 do
+                 queue := Min1 (snoc !queue (make i))
+               done;
+               let rec fold zero fn = function
+                 | Zero -> zero
+                 | One r -> fn zero (One r)
+                 | Many { head; tail; _ } as many ->
+                     exec many;
+                     fn
+                       (let head = next_of head ~tail in
+                        if head != tail then
+                          fold zero fn (Many { head; prev = tail; tail })
+                        else fold zero fn (generalize head))
+                       head
+               in
+               let open struct
+                 type t = { total : int; signaled : int; initial : int }
+               end in
+               let stats =
+                 fold { total = 0; signaled = 0; initial = 0 }
+                 @@ fun { total; signaled; initial } one ->
+                 let total = total + 1
+                 and signaled = signaled + Bool.to_int (is_signaled one)
+                 and initial = initial + Bool.to_int (not (is_signaled one)) in
+                 { total; signaled; initial }
+               in
+               let before =
+                 stats
+                   (match !queue with
+                   | Min1 (One r) -> One r
+                   | Min1 (Many r) -> Many r)
+               in
+               let after = stats (cleanup !queue ~count) in
+               assert (after.initial = before.initial);
+               assert (after.signaled <= before.signaled);
+               let last_bit = 1 lsl (n - 1) in
+               let last_kept =
+                 bits land last_bit = 0
+                 && 1 <> n
+                 && bits land lnot last_bit <> 0
+               in
+               if count = 1 then begin
+                 assert (
+                   after.signaled
+                   <= before.signaled
+                      - Bool.to_int (0 < before.signaled)
+                      + Bool.to_int last_kept)
+               end
+               else begin
+                 assert (after.total = after.initial + Bool.to_int last_kept)
+               end
+             done
+           done
+      end
+
+    let signal awaiters ~count =
+      let count = ref count in
+      match awaiters with
+      | Min1 (One one_r) -> signal_last_one (One one_r)
+      | Min1 (Many many_r as many) ->
+          exec many;
+          let tail = many_r.tail in
+          let head = ref tail in
+          let work = ref many_r.head in
+          while !work != tail do
+            if is_signaled !work then work := next_of !work ~tail
+            else if is_signalable !work then begin
+              signal_and_clear !work;
+              let next = next_of !work ~tail in
+              let n = !count - 1 in
+              count := n;
+              if n <> 0 then work := next
+              else begin
+                head := next;
+                work := tail
+              end
+            end
+            else begin
+              head := !work;
+              work := tail
+            end
+          done;
+          let head = !head in
+          if head == tail then
+            if !count <> 0 then signal_last_one head else last head
+          else begin
+            if !count <> 0 then begin
+              let prev = ref head in
+              let work = ref (next_of !prev ~tail) in
+              while !work != tail do
+                let next = next_of !work ~tail in
+                if is_signaled !work then begin
+                  set_next_of !prev next;
+                  work := next
+                end
+                else if is_signalable !work then begin
+                  signal_and_clear !work;
+                  set_next_of !prev next;
+                  let n = !count - 1 in
+                  count := n;
+                  if n <> 0 then work := next else work := tail
+                end
+                else begin
+                  prev := !work;
+                  work := next
+                end
+              done;
+              if !count <> 0 && is_signalable tail then signal_and_clear tail
+            end;
+            Many { head; prev = tail; tail }
+          end
+
+    let ( (* test signal *) ) =
+      if false then begin
+        [ 1; Int.max_int ]
+        |> List.iter @@ fun count ->
+           for n = 1 to 4 do
+             for signaled_bits = 0 to (1 lsl n) - 1 do
+               for signalable_bits = 0 to (1 lsl n) - 1 do
+                 let make i =
+                   let trigger = Trigger.create () in
+                   let value = signalable_bits land (1 lsl i) in
+                   let awaitable = make 0 and next = Min0 Zero in
+                   if signaled_bits land (1 lsl i) = 0 then
+                     Trigger.signal trigger;
+                   One { awaitable; value; trigger; counter = 0; next }
+                 in
+                 let queue = ref (Min1 (make 0)) in
+                 for i = 1 to n - 1 do
+                   queue := Min1 (snoc !queue (make i))
+                 done;
+                 let rec fold zero fn = function
+                   | Zero -> zero
+                   | One r -> fn zero (One r)
+                   | Many { head; tail; _ } as many ->
+                       exec many;
+                       fn
+                         (let head = next_of head ~tail in
+                          if head != tail then
+                            fold zero fn (Many { head; prev = tail; tail })
+                          else fold zero fn (generalize head))
+                         head
+                 in
+                 let open struct
+                   type t = {
+                     total : int;
+                     signalable : int;
+                     signaled : int;
+                     initial : int;
+                   }
+                 end in
+                 let stats =
+                   fold { total = 0; signalable = 0; signaled = 0; initial = 0 }
+                   @@ fun { total; signalable; signaled; initial } one ->
+                   let total = total + 1
+                   and signalable =
+                     signalable
+                     + Bool.to_int ((not (is_signaled one)) && is_signalable one)
+                   and signaled = signaled + Bool.to_int (is_signaled one)
+                   and initial =
+                     initial + Bool.to_int (not (is_signaled one))
+                   in
+                   { total; signalable; signaled; initial }
+                 in
+                 let before =
+                   stats
+                     (match !queue with
+                     | Min1 (One r) -> One r
+                     | Min1 (Many r) -> Many r)
+                 in
+                 let after = stats (signal !queue ~count) in
+                 (* The assertions here could be made stricter such that enough
+                    signaled awaiters should be removed from the queue.  Please
+                    make the assertions stricter if you plan to modify the
+                    signaling logic! *)
+                 if count = 1 then begin
+                   assert (
+                     (before.signalable = 0 && after.signalable = 0)
+                     || after.signalable + 1 = before.signalable)
+                 end
+                 else begin
+                   assert (after.signalable = 0)
+                 end
+               done
+             done
+           done
+      end
+  end
+
+  module Htbl = Picos_aux_htbl
+
+  let awaiters = Htbl.create ~hashed_type:(module Packed) ()
+
+  let update t ~signal ~count =
+    try
+      let signal = ref signal in
+      let backoff = ref Backoff.default in
+      while
+        not
+          (let before = Htbl.find_exn awaiters t in
+           match
+             if !signal then Awaiters.signal before ~count
+             else Awaiters.cleanup before ~count
+           with
+           | Zero -> Htbl.try_compare_and_remove awaiters t before
+           | One r ->
+               let after = Awaiters.Min1 (One r) in
+               before == after
+               || Htbl.try_compare_and_set awaiters t before after
+           | Many r ->
+               let after = Awaiters.Min1 (Many r) in
+               before == after
+               || Htbl.try_compare_and_set awaiters t before after)
+      do
+        signal := false;
+        backoff := Backoff.once !backoff
+      done
+    with Not_found -> ()
+
+  let add_as (type a) (t : a awaitable) value =
+    let trigger = Trigger.create () in
+    let one : Awaiters.is1 =
+      One { awaitable = t; value; trigger; counter = 0; next = Min0 Zero }
+    in
+    let backoff = ref Backoff.default in
+    while
+      not
+        (match Htbl.find_exn awaiters (Packed t) with
+        | before ->
+            let many = Awaiters.snoc before one in
+            Htbl.try_compare_and_set awaiters (Packed t) before (Min1 many)
+        | exception Not_found -> Htbl.try_add awaiters (Packed t) (Min1 one))
+    do
+      backoff := Backoff.once !backoff
+    done;
+    one
+
+  module Awaiter = struct
+    type t = Awaiters.is1
+
+    let add (type a) (t : a awaitable) =
+      add_as t (Sys.opaque_identity (Obj.magic awaiters : a))
+
+    let remove one =
+      Awaiters.signal_and_clear one;
+      update (Awaiters.awaitable_of one) ~signal:false ~count:1
+
+    let await one =
+      match Awaiters.await one with
+      | None -> ()
+      | Some exn_bt ->
+          Awaiters.clear one;
+          update (Awaiters.awaitable_of one) ~signal:true ~count:1;
+          Printexc.raise_with_backtrace (fst exn_bt) (snd exn_bt)
+  end
+
+  let await t value =
+    let one = add_as t value in
+    if Awaiters.is_signalable one then Awaiter.remove one else Awaiter.await one
+
+  let[@inline] broadcast t = update (Packed t) ~signal:true ~count:Int.max_int
+  let[@inline] signal t = update (Packed t) ~signal:true ~count:1
+
+  let () =
+    Stdlib.at_exit @@ fun () ->
+    match Htbl.find_random_exn awaiters with
+    | _ -> failwith "leaked awaitable"
+    | exception Not_found -> ()
+end

--- a/lib/picos_std.awaitable/picos_std_awaitable.mli
+++ b/lib/picos_std.awaitable/picos_std_awaitable.mli
@@ -1,0 +1,194 @@
+(** Basic {{:https://en.wikipedia.org/wiki/Futex} futex}-like awaitable atomic
+    location for {!Picos}. *)
+
+(** {1 Modules} *)
+
+module Awaitable : sig
+  (** An awaitable atomic location.
+
+      This module provides a superset of the Stdlib {!Atomic} API with more or
+      less identical performance.  The main difference is that a non-padded
+      awaitable location takes an extra word of memory.  Additionally a
+      {{:https://en.wikipedia.org/wiki/Futex} futex}-like API provides the
+      ability to {!await} until an awaitable location is explicitly {!signal}ed
+      to potentially have a different value.
+
+      Awaitable locations can be used to implement many kinds of synchronization
+      and communication primitives. *)
+
+  (** {1 Atomic API} *)
+
+  type 'a t
+  (** Represents an awaitable atomic location. *)
+
+  val make : ?padded:bool -> 'a -> 'a t
+  (** [make initial] creates a new awaitable atomic location with the given
+      [initial] value. *)
+
+  val make_contended : 'a -> 'a t
+  (** [make_contended initial] is equivalent to {{!make} [make ~padded:true initial]}. *)
+
+  val get : 'a t -> 'a
+  (** [get awaitable] is essentially equivalent to [Atomic.get awaitable]. *)
+
+  val compare_and_set : 'a t -> 'a -> 'a -> bool
+  (** [compare_and_set awaitable before after] is essentially equivalent to
+      [Atomic.compare_and_set awaitable before after]. *)
+
+  val exchange : 'a t -> 'a -> 'a
+  (** [exchange awaitable after] is essentially equivalent to [Atomic.exchange awaitable after]. *)
+
+  val set : 'a t -> 'a -> unit
+  (** [set awaitable value] is equivalent to {{!exchange} [exchange awaitable value |> ignore]}. *)
+
+  val fetch_and_add : int t -> int -> int
+  (** [fetch_and_add awaitable delta] is essentially equivalent to
+      [Atomic.fetch_and_add awaitable delta]. *)
+
+  val incr : int t -> unit
+  (** [incr awaitable] is equivalent to {{!fetch_and_add} [fetch_and_add awaitable (+1) |> ignore]}. *)
+
+  val decr : int t -> unit
+  (** [incr awaitable] is equivalent to {{!fetch_and_add} [fetch_and_add awaitable (-1) |> ignore]}. *)
+
+  (** {1 Futex API} *)
+
+  val signal : 'a t -> unit
+  (** [signal awaitable] tries to wake up one fiber {!await}in on the awaitable
+      location. *)
+
+  val broadcast : 'a t -> unit
+  (** [broadcast awaitable] tries to wake up all fibers {!await}ing on the
+      awaitable location. *)
+
+  val await : 'a t -> 'a -> unit
+  (** [await awaitable before] suspends the current fiber until the awaitable is
+      explicitly {!signal}ed and has a value other than [before].
+
+      ⚠️ This operation is subject to
+      {{:https://en.wikipedia.org/wiki/ABA_problem} ABA} problems.  An [await]
+      for value other than [A] may not return after the awaitable is signaled
+      while having the value [B], because at a later point the awaitable has
+      again the value [A].  Furthermore, by the time an [await] for value other
+      than [A] returns, the awaitable might already again have the value [A].
+
+      ⚠️ Atomic operations that change the value of an awaitable do not
+      implicitly wake up awaiters. *)
+
+  module Awaiter : sig
+    (** Ability to await for a signal from the past.
+
+        {!Awaitable.await} only receives a signal at or after the point of
+        calling it.  This API allows the awaiting process to be broken into two
+        steps, {!add} and {!await}, such that a signal after {!add} can be
+        received by {!await}. *)
+
+    type 'a awaitable := 'a t
+    (** An erased type alias for {!Awaitable.t}. *)
+
+    type t
+    (** Represents a single use awaiter of a signal to an {!awaitable}. *)
+
+    val add : 'a awaitable -> t
+    (** [add awaitable] create a single use awaiter, adds it to the FIFO
+        associated with the awaitable, and returns the awaiter. *)
+
+    val await : t -> unit
+    (** [await awaiter] awaits for the association awaitable to be signaled. *)
+
+    val remove : t -> unit
+    (** [remove awaiter] marks the awaiter as having been signaled and removes it
+        from the FIFO associated with the awaitable.
+
+        ⚠️ An explicit call of [remove] is needed when an {!add}ed awaiter is not
+        {!await}ed for.  In such a case, from the point of view of lost signals,
+        the caller of [remove] should be considered to have received or consumed
+        a signal before the call of [remove]. *)
+  end
+end
+
+(** {1 Examples}
+
+    We first open the library to bring the {!Awaitable} module into scope:
+
+    {[
+      # open Picos_std_awaitable
+    ]}
+
+    {2 [Mutex]}
+
+    Here is a basic mutex implementation using awaitables:
+
+    {[
+      module Mutex = struct
+        type t = int Awaitable.t
+
+        let create ?padded () = Awaitable.make ?padded 0
+
+        let rec lock t old =
+          if old <> 0 then begin
+            Awaitable.await t 2;
+            lock t (Awaitable.exchange t 2)
+          end
+
+        let lock t =
+          if not (Awaitable.compare_and_set t 0 1) then
+            lock t (Awaitable.exchange t 2)
+
+        let unlock ?checked:_ t =
+          let before = Awaitable.fetch_and_add t (-1) in
+          if before = 2 then begin
+            Awaitable.set t 0;
+            Awaitable.signal t
+          end
+      end
+    ]}
+
+    The above mutex outperforms most other mutexes under both no/low and high
+    contention scenarios.  In no/low contention scenarios the use
+    [fetch_and_add] provides low overhead.  In high contention scenarios the
+    above mutex allows unfairness, which avoids
+    {{:https://en.wikipedia.org/wiki/Lock_convoy} lock convoy}.
+
+    {2 [Condition]}
+
+    Let's also implement a condition variable.  For that we'll also make use
+    low level operations in the {!Picos} core library:
+
+    {[
+      # open Picos
+    ]}
+
+    To implement a condition variable, we'll use the {{!Awaitable.Awaiter}
+    [Awaiter]} API:
+
+    {[
+      module Condition = struct
+        type t = unit Awaitable.t
+
+        let create () = Awaitable.make ()
+
+        let wait t mutex =
+          let awaiter = Awaitable.Awaiter.add t in
+          Mutex.unlock mutex;
+          let lock_forbidden mutex =
+            let fiber = Fiber.current () in
+            let forbid = Fiber.exchange fiber ~forbid:true in
+            Mutex.lock mutex;
+            Fiber.set fiber ~forbid
+          in
+          match Awaitable.Awaiter.await awaiter with
+          | () -> lock_forbidden mutex
+          | exception exn ->
+              let bt = Printexc.get_raw_backtrace () in
+              lock_forbidden mutex;
+              Printexc.raise_with_backtrace exn bt
+
+        let signal = Awaitable.signal
+        let broadcast = Awaitable.broadcast
+      end
+    ]}
+
+    Notice that the awaitable location used in the above condition variable
+    implementation is never mutated.  We just reuse the signaling mechanism of
+    awaitables. *)

--- a/lib/picos_std/index.mld
+++ b/lib/picos_std/index.mld
@@ -5,6 +5,7 @@ the modules are intentionally designed to mimic modules from the OCaml Stdlib.
 
 {!modules:
   Picos_std_finally
+  Picos_std_awaitable
   Picos_std_event
   Picos_std_structured
   Picos_std_sync


### PR DESCRIPTION
This PR adds a futex-like awaitable atomic location abstraction.  This can be useful for implementing various kinds of synchronization and communication primitives.  For example, it can be used to implement mutexes and condition variables with good performance.  Below shows the speed up obtained by replacing the fair mutex and condition with unfair mutex and condition implemented using the awaitable abstraction:

![Screenshot 2024-10-21 at 20 19 14](https://github.com/user-attachments/assets/b5c1ee3c-20ae-4503-9ec0-a81a79371cbe)