### PR TITLE
Make sure `sherlodoc` is installed when updating docs

### DIFF
--- a/update-gh-pages-for-tag
+++ b/update-gh-pages-for-tag
@@ -28,6 +28,8 @@ EOF
   exit 1
 fi
 
+opam install sherlodoc
+
 mkdir $TMP
 cd $TMP
 


### PR DESCRIPTION
I noticed I had updated docs without `sherlodoc`, which results in not having the nice search bar with the docs.  This should prevent that from happening again.