### PR TITLE
Refine the `Awaitable` abstraction

### DIFF
--- a/lib/picos_std.awaitable/dune
+++ b/lib/picos_std.awaitable/dune
@@ -1,7 +1,11 @@
 (library
  (name picos_std_awaitable)
  (public_name picos_std.awaitable)
- (libraries picos picos_aux.htbl backoff multicore-magic))
+ (libraries
+  (re_export picos)
+  picos_aux.htbl
+  backoff
+  multicore-magic))
 
 (mdx
  (package picos_meta)


### PR DESCRIPTION
The use of `Trigger` is exposed to allow awaiting for multiple things.

The internal cleanup is made more robust to make sure awaitables will not be leaked.
