### PR TITLE
Dependencies of cohttp don't like OpenBSD

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -86,13 +86,16 @@
 
 (package
  (name picos_io_cohttp)
+ (allow_empty)
  (synopsis "Cohttp running on Picos IO")
  (depends
   (picos_io
    (= :version))
   ;;
   (cohttp
-   (>= 6.0.0~beta2))
+   (and
+    (>= 6.0.0~beta2)
+    (<> :os "openbsd")))
   (fmt
    (>= 0.9.0))
   (uri
@@ -150,7 +153,9 @@
   (picos_io
    (= :version))
   (picos_io_cohttp
-   (= :version))
+   (and
+    (= :version)
+    (<> :os "openbsd")))
   (picos_mux
    (= :version))
   (picos_lwt
@@ -176,16 +181,19 @@
   (cohttp
    (and
     (>= 6.0.0~beta2)
+    (<> :os "openbsd")
     :with-test))
   (cohttp-lwt-unix
    (and
     (>= 6.0.0~beta2)
     (<> :os "win32")
+    (<> :os "openbsd")
     :with-test))
   (conduit-lwt-unix
    (and
     (>= 6.2.2)
     (<> :os "win32")
+    (<> :os "openbsd")
     :with-test))
   (conf-npm
    (and
@@ -224,6 +232,7 @@
   (cohttp-lwt
    (and
     (>= 6.0.0~beta2)
+    (<> :os "openbsd")
     :with-test))
   (qcheck-multicoretests-util
    (and

--- a/lib/picos_io_cohttp/dune
+++ b/lib/picos_io_cohttp/dune
@@ -1,6 +1,7 @@
 (library
  (name picos_io_cohttp)
  (public_name picos_io_cohttp)
+ (optional)
  (libraries
   (re_export cohttp)
   (re_export picos_io)
@@ -13,6 +14,7 @@
  (package picos_meta)
  (enabled_if
   (and
+   (<> %{system} "openbsd")
    (>= %{ocaml_version} 5.1.0)
    (= %{env:OPAM_REPO_CI=false} false)))
  (libraries

--- a/picos_io_cohttp.opam
+++ b/picos_io_cohttp.opam
@@ -10,7 +10,7 @@ bug-reports: "https://github.com/ocaml-multicore/picos/issues"
 depends: [
   "dune" {>= "3.14"}
   "picos_io" {= version}
-  "cohttp" {>= "6.0.0~beta2"}
+  "cohttp" {>= "6.0.0~beta2" & os != "openbsd"}
   "fmt" {>= "0.9.0"}
   "uri" {>= "4.4.0"}
   "odoc" {with-doc}

--- a/picos_meta.opam
+++ b/picos_meta.opam
@@ -13,7 +13,7 @@ depends: [
   "picos_aux" {= version}
   "picos_std" {= version}
   "picos_io" {= version}
-  "picos_io_cohttp" {= version}
+  "picos_io_cohttp" {= version & os != "openbsd"}
   "picos_mux" {= version}
   "picos_lwt" {= version}
   "dscheck" {>= "0.4.0"}
@@ -22,9 +22,11 @@ depends: [
   "qcheck-stm" {>= "0.3"}
   "alcotest" {>= "1.7.0" & with-test}
   "backoff" {>= "0.1.0" & with-test}
-  "cohttp" {>= "6.0.0~beta2" & with-test}
-  "cohttp-lwt-unix" {>= "6.0.0~beta2" & os != "win32" & with-test}
-  "conduit-lwt-unix" {>= "6.2.2" & os != "win32" & with-test}
+  "cohttp" {>= "6.0.0~beta2" & os != "openbsd" & with-test}
+  "cohttp-lwt-unix"
+    {>= "6.0.0~beta2" & os != "win32" & os != "openbsd" & with-test}
+  "conduit-lwt-unix"
+    {>= "6.2.2" & os != "win32" & os != "openbsd" & with-test}
   "conf-npm"
     {arch != "x86_32" & arch != "riscv64" & os != "win32" & with-test}
   "domain_shims" {>= "0.1.0" & with-test}
@@ -34,7 +36,7 @@ depends: [
   "multicore-magic" {>= "2.3.0" & with-test}
   "multicore-magic-dscheck" {>= "2.3.0" & with-test}
   "ocaml-version" {>= "3.6.4" & with-test}
-  "cohttp-lwt" {>= "6.0.0~beta2" & with-test}
+  "cohttp-lwt" {>= "6.0.0~beta2" & os != "openbsd" & with-test}
   "qcheck-multicoretests-util" {>= "0.3" & with-test}
   "uri" {>= "4.4.0" & with-test}
   "odoc" {>= "2.4.1" & with-doc}

--- a/test/dune
+++ b/test/dune
@@ -120,6 +120,7 @@
  (package picos_meta)
  (name test_io_cohttp)
  (modules test_io_cohttp)
+ (build_if %{lib-available:picos_io_cohttp})
  (libraries
   picos_io_cohttp
   picos_std.finally
@@ -273,6 +274,7 @@
  (build_if
   (and
    (>= %{ocaml_version} 5)
+   %{lib-available:cohttp-lwt-unix}
    %{lib-available:conduit-lwt-unix}))
  (libraries
   cohttp


### PR DESCRIPTION
I also mentioned these on the OCaml Labs slack.  Let's wait a bit before merging this workaround.