### PR TITLE
Don't refer to `caml_ml_domain_id` on OCaml 4

### DIFF
--- a/lib/picos.thread/thread.ocaml4.js
+++ b/lib/picos.thread/thread.ocaml4.js
@@ -7,10 +7,9 @@ function caml_thread_initialize(unit) {
 var caml_thread = [0, 0, 0, 0]
 
 //Provides: caml_thread_self
-//Requires: caml_ml_domain_id, caml_failwith, caml_thread
+//Requires: caml_thread
 function caml_thread_self(unit) {
-  if (caml_ml_domain_id(unit) != caml_thread[1])
-    caml_failwith('caml_thread_self: spawning of domains is not supported')
+  // There are no threads other than the main thread.
   return caml_thread
 }
 


### PR DESCRIPTION
See #332