### PR TITLE
Add `Rwlock`

### DIFF
--- a/lib/picos_std.sync/picos_std_sync.ml
+++ b/lib/picos_std.sync/picos_std_sync.ml
@@ -2,6 +2,7 @@ module Mutex = Mutex
 module Condition = Condition
 module Semaphore = Semaphore
 module Lock = Lock
+module Rwlock = Rwlock
 module Sem = Sem
 module Lazy = Lazy
 module Latch = Latch

--- a/lib/picos_std.sync/rwlock.ml
+++ b/lib/picos_std.sync/rwlock.ml
@@ -1,0 +1,176 @@
+open Picos_std_awaitable
+
+(** TODO: Should we try to prevent writers from starvation? *)
+
+type t = int Awaitable.t
+
+let no_writers = 1 lsl 0
+let no_readers = 1 lsl 1
+let no_awaiters = no_readers lor no_writers
+let shared = 1 lsl 2
+let shared_permanently = 1 lsl (Sys.int_size - 5)
+let exclusive = 1 lsl (Sys.int_size - 4)
+let exclusive_permanently = 1 lsl (Sys.int_size - 2)
+
+exception Poisoned
+exception Frozen
+
+let acquire t =
+  let before = no_awaiters in
+  let after = exclusive lor no_awaiters in
+  if not (Awaitable.compare_and_set t before after) then
+    let rec acquire_awaiting t =
+      let before = Awaitable.get t in
+      if before < shared then begin
+        let after = before land lnot no_writers lor exclusive in
+        if not (Awaitable.compare_and_set t before after) then
+          acquire_awaiting t
+      end
+      else if shared_permanently / 2 <= before land lnot exclusive then
+        raise (if exclusive < before then Poisoned else Frozen)
+      else
+        let after = before land lnot no_writers in
+        if before = after || Awaitable.compare_and_set t before after then
+          Awaitable.await t after;
+        acquire_awaiting t
+    in
+    acquire_awaiting t
+
+let release t =
+  let before = exclusive lor no_awaiters in
+  let after = no_awaiters in
+  if not (Awaitable.compare_and_set t before after) then
+    let rec release_contended t =
+      let before = Awaitable.get t in
+      if before land lnot exclusive < shared_permanently / 2 then
+        let after = before land lnot exclusive lor no_awaiters in
+        if Awaitable.compare_and_set t before after then begin
+          if before land no_awaiters <> no_awaiters then
+            if before land no_readers = 0 then Awaitable.broadcast t
+            else Awaitable.signal t
+        end
+        else release_contended t
+    in
+    release_contended t
+
+let acquire_shared t =
+  let prior = Awaitable.fetch_and_add t shared in
+  if exclusive <= prior then
+    let rec acquire_shared_awaiting t =
+      let before = Awaitable.get t in
+      if before < exclusive then begin
+        let after = (before + shared) land lnot no_readers in
+        if not (Awaitable.compare_and_set t before after) then
+          acquire_shared_awaiting t
+      end
+      else if exclusive_permanently / 2 <= before then raise Poisoned
+      else
+        let after = before land lnot no_readers in
+        if before = after || Awaitable.compare_and_set t before after then
+          Awaitable.await t after;
+        acquire_shared_awaiting t
+    in
+    let rec acquire_shared_contended t =
+      let before = Awaitable.get t in
+      if exclusive <= before then
+        let after = (before - shared) land lnot no_readers in
+        if Awaitable.compare_and_set t before after then
+          acquire_shared_awaiting t
+        else acquire_shared_contended t
+    in
+    acquire_shared_contended t
+
+let release_shared t =
+  let prior = Awaitable.fetch_and_add t (-shared) in
+  if prior < shared lor no_awaiters then
+    let rec signal_awaiters t =
+      let before = Awaitable.get t in
+      if before < no_awaiters then
+        if Awaitable.compare_and_set t before (before lor no_awaiters) then
+          if no_readers <= before then Awaitable.signal t
+          else Awaitable.broadcast t
+        else signal_awaiters t
+    in
+    signal_awaiters t
+  else if exclusive_permanently / 2 < prior then
+    let undo_release t =
+      let _ : int = Awaitable.fetch_and_add t shared in
+      ()
+    in
+    undo_release t
+
+let rec poison t =
+  let before = Awaitable.get t in
+  if before < exclusive then invalid_arg "not write locked";
+  (* Unfortunately we cannot check ownership at this point. *)
+  if before < exclusive_permanently / 2 then
+    let after = exclusive_permanently lor no_awaiters in
+    if Awaitable.compare_and_set t before after then Awaitable.broadcast t
+    else poison t
+
+let freeze t =
+  acquire_shared t;
+  let before = ref (Awaitable.get t) in
+  while
+    !before < shared_permanently / 2
+    &&
+    let after = (!before + shared_permanently) lor no_awaiters in
+    (* This leaves the rwlock as read locked. *)
+    not (Awaitable.compare_and_set t !before after)
+  do
+    before := Awaitable.get t
+  done;
+  (* We must wake up any writers waiting to obtain the lock. *)
+  if !before land no_awaiters <> no_awaiters then Awaitable.broadcast t;
+  release_shared t
+
+let holding t thunk = Locks.holding t thunk ~acquire ~release ~poison
+let protect t thunk = Locks.protect t thunk ~acquire ~release
+
+let sharing t thunk =
+  acquire_shared t;
+  match thunk () with
+  | value ->
+      release_shared t;
+      value
+  | exception exn ->
+      let bt = Printexc.get_raw_backtrace () in
+      release_shared t;
+      Printexc.raise_with_backtrace exn bt
+
+let try_acquire t =
+  let before = Awaitable.get t in
+  if before < shared then
+    Awaitable.compare_and_set t before (before lor exclusive)
+  else
+    shared_permanently / 2 <= before land lnot exclusive
+    && raise (if exclusive < before then Poisoned else Frozen)
+
+let try_acquire_shared t =
+  let before = Awaitable.get t in
+  if before < exclusive then Awaitable.compare_and_set t before (before + shared)
+  else exclusive_permanently / 2 <= before && raise Poisoned
+
+let[@inline] create ?padded () = Awaitable.make ?padded no_awaiters
+let[@inline] is_locked t = exclusive <= Awaitable.get t
+
+let[@inline] is_frozen t =
+  let state = Awaitable.get t in
+  shared_permanently / 2 <= state && state < exclusive
+
+let[@inline] is_poisoned t = exclusive_permanently / 2 <= Awaitable.get t
+
+let[@inline] is_locked_shared t =
+  let state = Awaitable.get t in
+  shared <= state && state < exclusive
+
+module Condition = struct
+  type lock = t
+
+  include Conditions
+
+  let wait_shared condition lock =
+    wait condition lock ~acquire:acquire_shared ~release:release_shared
+
+  let wait condition lock = wait condition lock ~acquire ~release
+end

--- a/test/dune
+++ b/test/dune
@@ -45,6 +45,13 @@
    (run %{test} -- "^Lock and Lock.Condition$" 1)
    (run %{test} -- "^Lock and Lock.Condition$" 2)
    (run %{test} -- "^Lock and Lock.Condition$" 3)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 0)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 1)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 2)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 3)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 4)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 5)
+   (run %{test} -- "^Rwlock and Rwlock.Condition$" 6)
    ;;
    )))
 
@@ -64,6 +71,12 @@
  (package picos_meta)
  (name test_sem)
  (modules test_sem)
+ (libraries picos picos_std.sync stm_run stm_wrap))
+
+(test
+ (package picos_meta)
+ (name test_rwlock)
+ (modules test_rwlock)
  (libraries picos picos_std.sync stm_run stm_wrap))
 
 ;;

--- a/test/test_rwlock.ml
+++ b/test/test_rwlock.ml
@@ -1,0 +1,80 @@
+open QCheck
+open STM
+open Picos_std_sync
+
+module Spec = struct
+  include SpecDefaults
+  include Stm_wrap
+
+  type cmd = Push of int | Pop_opt | Top_opt | Length
+
+  let show_cmd = function
+    | Push x -> "Push " ^ string_of_int x
+    | Pop_opt -> "Pop_opt"
+    | Top_opt -> "Top_opt"
+    | Length -> "Length"
+
+  module State = struct
+    type t = int list
+
+    let push x xs = x :: xs
+    let pop_opt = function _ :: xs -> xs | [] -> []
+    let top_opt = function x :: _ -> Some x | [] -> None
+    let length = List.length
+  end
+
+  type state = State.t
+  type sut = { stack : int Stack.t; rwlock : Rwlock.t }
+
+  let arb_cmd _s =
+    [
+      Gen.int_range 1 1000 |> Gen.map (fun x -> Push x);
+      Gen.return Pop_opt;
+      Gen.return Top_opt;
+      Gen.return Length;
+    ]
+    |> Gen.oneof |> make ~print:show_cmd
+
+  let init_state = []
+  let init_sut () = { stack = Stack.create (); rwlock = Rwlock.create () }
+
+  let next_state c s =
+    match c with
+    | Push x -> State.push x s
+    | Pop_opt -> State.pop_opt s
+    | Top_opt -> s
+    | Length -> s
+
+  let run c d =
+    match c with
+    | Push x ->
+        Rwlock.acquire d.rwlock;
+        Stack.push x d.stack;
+        Rwlock.release d.rwlock;
+        Res (unit, ())
+    | Pop_opt ->
+        Rwlock.acquire d.rwlock;
+        let result = Stack.pop_opt d.stack in
+        Rwlock.release d.rwlock;
+        Res (option int, result)
+    | Top_opt ->
+        Rwlock.acquire_shared d.rwlock;
+        let result = Stack.top_opt d.stack in
+        Rwlock.release_shared d.rwlock;
+        Res (option int, result)
+    | Length ->
+        Rwlock.acquire_shared d.rwlock;
+        let result = Stack.length d.stack in
+        Rwlock.release_shared d.rwlock;
+        Res (int, result)
+
+  let postcond c (s : state) res =
+    match (c, res) with
+    | Push _x, Res ((Unit, _), ()) -> true
+    | Pop_opt, Res ((Option Int, _), res) -> res = State.top_opt s
+    | Top_opt, Res ((Option Int, _), res) -> res = State.top_opt s
+    | Length, Res ((Int, _), res) -> res = State.length s
+    | _, _ -> false
+end
+
+let () = Stm_run.run ~name:"Rwlock" (module Spec) |> exit


### PR DESCRIPTION
This PR adds a low overhead `Rwlock`, with an associated `Condition` variable, using the `Awaitable` abstraction.

For future work:
- Experiment with alternatives to prevent writer starvation.  The simple approach of just immediately making readers wait when there is a writer waiting decreases performance.