### PR TITLE
Add a poisonable `Barrier` to `picos_std.sync`

### DIFF
--- a/lib/picos_std.sync/barrier.ml
+++ b/lib/picos_std.sync/barrier.ml
@@ -1,0 +1,74 @@
+open Picos_std_awaitable
+
+type t = int Awaitable.t
+
+let sense_bit = 1
+let parties_shift = 1
+let parties_bits = (Sys.int_size - 2) / 2
+let max_parties = (1 lsl parties_bits) - 1
+let parties_mask = max_parties lsl parties_shift
+let awaiting_shift = parties_shift + parties_bits
+let awaiting_one = 1 lsl awaiting_shift
+let poisoned_bit = Int.min_int
+
+let create ?padded parties =
+  if parties <= 0 || max_parties < parties then
+    invalid_arg "invalid number of parties";
+  Awaitable.make ?padded
+    ((parties lsl parties_shift) lor (parties lsl awaiting_shift))
+
+exception Poisoned
+
+let rec poison t =
+  let before = Awaitable.get t in
+  if 0 < before then
+    let after =
+      let parties_shifted = before land parties_mask in
+      let after_sense = lnot before land sense_bit in
+      parties_shifted lor after_sense
+      lor (max_parties lsl awaiting_shift)
+      lor poisoned_bit
+    in
+    if Awaitable.compare_and_set t before after then Awaitable.broadcast t
+    else poison t
+
+let await t =
+  let[@inline never] poison_and_raise t =
+    poison t;
+    raise Poisoned
+  in
+  let prior = Awaitable.fetch_and_add t (-awaiting_one) in
+  if awaiting_one < prior then begin
+    let before = prior - awaiting_one in
+    let after_sense = prior land sense_bit lxor sense_bit in
+    if before < awaiting_one then
+      let after =
+        let parties_shifted = before land parties_mask in
+        parties_shifted lor after_sense
+        lor (parties_shifted lsl (awaiting_shift - parties_shift))
+      in
+      if Awaitable.compare_and_set t before after then Awaitable.broadcast t
+      else
+        (* The barrier is being misused?  Poison the barrier. *)
+        poison_and_raise t
+    else
+      let state = ref before in
+      match
+        while !state land sense_bit <> after_sense do
+          Awaitable.await t !state;
+          state := Awaitable.get t
+        done
+      with
+      | () -> if 0 <= !state then () else raise Poisoned
+      | exception exn ->
+          let bt = Printexc.get_raw_backtrace () in
+          poison t;
+          Printexc.raise_with_backtrace exn bt
+  end
+  else begin
+    (* The barrier was poisoned.  Undo the decrement. *)
+    Awaitable.fetch_and_add t awaiting_one |> ignore;
+    poison_and_raise t
+  end
+
+let parties t = (Awaitable.get t land parties_mask) lsr parties_shift

--- a/lib/picos_std.sync/picos_std_sync.ml
+++ b/lib/picos_std.sync/picos_std_sync.ml
@@ -6,5 +6,6 @@ module Rwlock = Rwlock
 module Sem = Sem
 module Lazy = Lazy
 module Latch = Latch
+module Barrier = Barrier
 module Ivar = Ivar
 module Stream = Stream

--- a/lib/picos_std.sync/picos_std_sync.mli
+++ b/lib/picos_std.sync/picos_std_sync.mli
@@ -481,6 +481,42 @@ module Sem : sig
       {{!poison} poisoned}. *)
 end
 
+module Barrier : sig
+  (** A poisonable barrier. *)
+
+  type t
+  (** Represents a poisonable barrier. *)
+
+  val max_parties : int
+  (** Maximum number of participants that a barrier can be configured with. *)
+
+  val create : ?padded:bool -> int -> t
+  (** [create parties] creates a new barrier for given number of parties.
+
+      @raise Invalid_argument
+        in case the given number of [parties] is less than [1] or greater than
+        [max_parties]. *)
+
+  val parties : t -> int
+  (** [paries barrier] returns the number of parties the barrier was
+      {{!create} created} with. *)
+
+  exception Poisoned
+  (** Exception raised by {!await} in case the barrier has become poisoned. *)
+
+  val await : t -> unit
+  (** [await barrier] awaits until the configured number of {!parties} has
+      called [await] on the barrier and returns, or raises {!Poisoned} in case
+      the barrier has become poisoned.
+
+      ℹ️ If the await is canceled, then [await] will {!poison} the barrier before
+      reraising the cancelation exception. *)
+
+  val poison : t -> unit
+  (** [poison barrier] marks the barrier as poisoned. Concurrent and subsequent
+      calls of {!await} will raise the {!Poisoned} exception. *)
+end
+
 module Lazy : sig
   (** A lazy suspension.
 

--- a/test/dune
+++ b/test/dune
@@ -51,6 +51,8 @@
    (run %{test} -- "^Lazy$" 0)
    (run %{test} -- "^Lazy$" 1)
    (run %{test} -- "^Event$" 0)
+   (run %{test} -- "^Barrier$" 0)
+   (run %{test} -- "^Barrier$" 1)
    (run %{test} -- "^Non-cancelable ops$" 0)
    ;;
    )))


### PR DESCRIPTION
This PR adds a slim poisonable barrier to `picos_std.sync` &mdash; the barrier state and configuration is stored in a single `int Awaitable.t`.  The state of the barrier is mostly updated using `fetch_and_add`, which should perform well.

In the future the bit manipulation logic could probably be tweaked or the OCaml compiler improved save a few instructions.  The potential performance improvement from that is likely to be tiny, however.