### PR TITLE
Allocate the trigger for a bundle lazily

### DIFF
--- a/lib/picos/picos.mli
+++ b/lib/picos/picos.mli
@@ -212,6 +212,9 @@ module Trigger : sig
       🏎️ A trigger in the initial and signaled states is a tiny object that does
       not hold onto any other objects. *)
 
+  val signaled : t
+  (** [signaled] is a constant trigger that has already been signaled. *)
+
   val create : unit -> t
   (** [create ()] allocates a new trigger in the initial state. *)
 

--- a/lib/picos/picos.ocaml5.ml
+++ b/lib/picos/picos.ocaml5.ml
@@ -10,6 +10,8 @@ module Trigger = struct
 
   and t = state Atomic.t
 
+  let signaled = Atomic.make Signaled
+
   let finish t ~allow_awaiting =
     match Atomic.get t with
     | Signaled -> ()


### PR DESCRIPTION
This slightly reduces memory usage of a bundle until the trigger is actually needed, which might be never.