### PR TITLE
Use heartbeats to wake up runners in multififo

### DIFF
--- a/lib/picos_mux.multififo/dune
+++ b/lib/picos_mux.multififo/dune
@@ -12,4 +12,5 @@
    (-> select.none.ml))
   multicore-magic
   picos.thread
-  picos_aux.mpmcq))
+  picos_aux.mpmcq
+  threads.posix))

--- a/lib/picos_mux.multififo/picos_mux_multififo.mli
+++ b/lib/picos_mux.multififo/picos_mux_multififo.mli
@@ -27,8 +27,8 @@ type t
 (** Represents a shared context for fifo runners. *)
 
 val context : ?quota:int -> ?fatal_exn_handler:(exn -> unit) -> unit -> t
-(** [context ()] creates a new context for randomized runners. The context
-    should be consumed by a call of {{!run} [run ~context ...]}.
+(** [context ()] creates a new context for randomized runners. The context must
+    always be consumed by a call of {{!run} [run ~context ...]}.
 
     The optional [quota] argument defaults to [Int.max_int] and determines the
     number of effects a fiber is allowed to perform before it is forced to


### PR DESCRIPTION
This changes the multififo scheduler to wakeup runners only on periodic heartbeats.  This avoids the thundering herd problem.  A separate heartbeat thread is used to maintain the property that if there are `n` ready fibers that never yield and terminate (only) if run in parallel, and the scheduler runs with `n` (or more domains), then such a program will terminate, i.e. that the `n` fibers will eventually run on `n` different domains.