### PR TITLE
More benchmarks with the multififo scheduler

### DIFF
--- a/bench/dune
+++ b/bench/dune
@@ -47,7 +47,7 @@
   (select
    scheduler.ml
    from
-   (picos_mux.fifo -> scheduler.ocaml5.ml)
+   (picos_mux.multififo -> scheduler.ocaml5.ml)
    (picos_mux.thread -> scheduler.ocaml4.ml))
   (select
    bench_fib.ml

--- a/bench/scheduler.ocaml5.ml
+++ b/bench/scheduler.ocaml5.ml
@@ -1,1 +1,1 @@
-let run main = Picos_mux_fifo.run ~quota:100 main
+let run main = Picos_mux_multififo.run_on ~quota:100 ~n_domains:1 main


### PR DESCRIPTION
For practical reasons, benchmark primarily with the multififo scheduler.