### PR TITLE
Bench queues with heap allocated blocks

### DIFF
--- a/bench/bench_bounded_q.ml
+++ b/bench/bench_bounded_q.ml
@@ -86,7 +86,7 @@ let run_one_domain ~budgetf ?(n_msgs = 25 * Util.iter_factor) () =
   let t = Bounded_q.create () in
 
   let op push =
-    if push then Bounded_q.push t 101 else Bounded_q.pop_opt t |> ignore
+    if push then Bounded_q.push t (ref push) else Bounded_q.pop_opt t |> ignore
   in
 
   let init _ =
@@ -128,7 +128,7 @@ let run_one ~budgetf ~n_adders ~n_takers ?(n_msgs = 10 * Util.iter_factor) () =
         let n = Countdown.alloc n_msgs_to_add ~domain_index ~batch:100 in
         if 0 < n then begin
           for i = 1 to n do
-            Bounded_q.push t i
+            Bounded_q.push t (ref i)
           done;
           work ()
         end

--- a/bench/bench_mpmcq.ml
+++ b/bench/bench_mpmcq.ml
@@ -5,7 +5,7 @@ let run_one_domain ~budgetf ?(n_msgs = 50 * Util.iter_factor) () =
   let t = Mpmcq.create ~padded:true () in
 
   let op push =
-    if push then Mpmcq.push t 101
+    if push then Mpmcq.push t (ref push)
     else match Mpmcq.pop_exn t with _ -> () | exception Mpmcq.Empty -> ()
   in
 
@@ -41,7 +41,7 @@ let run_one ~budgetf ~n_adders ~n_takers () =
         let n = Countdown.alloc n_msgs_to_add ~domain_index:i ~batch:1000 in
         if 0 < n then begin
           for i = 1 to n do
-            Mpmcq.push t i
+            Mpmcq.push t (ref i)
           done;
           work ()
         end

--- a/bench/bench_mpscq.ml
+++ b/bench/bench_mpscq.ml
@@ -5,7 +5,7 @@ let run_one_domain ~budgetf ?(n_msgs = 50 * Util.iter_factor) () =
   let t = Mpscq.create ~padded:true () in
 
   let op push =
-    if push then Mpscq.push t 101
+    if push then Mpscq.push t (ref push)
     else match Mpscq.pop_exn t with _ -> () | exception Mpscq.Empty -> ()
   in
 
@@ -40,7 +40,7 @@ let run_one ~budgetf ~n_adders () =
         let n = Countdown.alloc n_msgs_to_add ~domain_index:i ~batch:1000 in
         if 0 < n then begin
           for i = 1 to n do
-            Mpscq.push t i
+            Mpscq.push t (ref i)
           done;
           work ()
         end

--- a/bench/bench_stream.ml
+++ b/bench/bench_stream.ml
@@ -7,7 +7,7 @@ let run_one_domain ~budgetf ?(n_msgs = 50 * Util.iter_factor) () =
   let cursor = ref (Stream.tap t) in
 
   let op push =
-    if push then Stream.push t 101
+    if push then Stream.push t (ref push)
     else
       match Stream.peek_opt !cursor with
       | None -> ()
@@ -44,7 +44,7 @@ let run_one ~budgetf ~n_pusher () =
         let n = Util.alloc n_msgs_to_add in
         if 0 < n then begin
           for i = 1 to n do
-            Stream.push t i
+            Stream.push t (ref i)
           done;
           work ()
         end


### PR DESCRIPTION
Queues were previously benchmarked with immediate values only, which unfortunately partially hides the potential cost of write barriers related to setting and clearing elements.